### PR TITLE
Reactive cycle improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ Data from a resource signal comes in the following format:
 
 ```typescript
 type AsyncData<T> = {
-  data: T | null; // The data fetched from the server. It is null until the data is fetched
+  data: ReadOnlySignal<T> | null; // The data fetched from the server. It is null until the data is fetched
   loading: boolean; // A boolean that indicates if the data is being fetched
   error: unknown | null; // An error object that is populated if the fetch fails
 };
@@ -606,6 +606,9 @@ export default class ContactList extends LightningElement {
 ```
 
 ### Mutating `$resource` data
+
+Notice that the data returned by a resource is a ReadOnlySignal.
+This means that you cannot mutate the data directly, so how can you update the data?
 
 Besides `refetch`, the `$resource` function also returns a `mutate` function that allows you to mutate the data.
 

--- a/force-app/lwc/signals/core.js
+++ b/force-app/lwc/signals/core.js
@@ -129,9 +129,6 @@ function $signal(value, options) {
     return _storageOption.get();
   }
   function setter(newValue) {
-    // TODO: New unit test for resources since this fixes a bug where it was always reevaluating
-    // TODO: because it was checking for object equality, which in the case of a resource was always false.
-    // TODO: The unit test should fail before, and pass with these changes
     if (deepEqual(newValue, _storageOption.get())) {
       return;
     }

--- a/force-app/lwc/signals/core.js
+++ b/force-app/lwc/signals/core.js
@@ -191,8 +191,7 @@ function $resource(fn, source, options) {
       let data = null;
       if (_fetchWhen()) {
         const derivedSource = derivedSourceFn();
-        // TODO: Use deepEquality to compare the derivedSource to previousParams
-        if (!_isInitialLoad && derivedSource === _previousParams) {
+        if (!_isInitialLoad && deepEqual(derivedSource, _previousParams)) {
           // No need to fetch the data again if the params haven't changed
           return;
         }

--- a/force-app/lwc/signals/observable-membrane/base-handler.js
+++ b/force-app/lwc/signals/observable-membrane/base-handler.js
@@ -7,126 +7,162 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { ArrayConcat, getPrototypeOf, getOwnPropertyNames, getOwnPropertySymbols, getOwnPropertyDescriptor, isUndefined, isExtensible, hasOwnProperty, ObjectDefineProperty, preventExtensions, ArrayPush, ObjectCreate, } from './shared';
+import {
+  ArrayConcat,
+  getPrototypeOf,
+  getOwnPropertyNames,
+  getOwnPropertySymbols,
+  getOwnPropertyDescriptor,
+  isUndefined,
+  isExtensible,
+  hasOwnProperty,
+  ObjectDefineProperty,
+  preventExtensions,
+  ArrayPush,
+  ObjectCreate
+} from "./shared";
 export class BaseProxyHandler {
-    constructor(membrane, value) {
-        this.originalTarget = value;
-        this.membrane = membrane;
+  constructor(membrane, value) {
+    this.originalTarget = value;
+    this.membrane = membrane;
+  }
+  // Shared utility methods
+  wrapDescriptor(descriptor) {
+    if (hasOwnProperty.call(descriptor, "value")) {
+      descriptor.value = this.wrapValue(descriptor.value);
+    } else {
+      const { set: originalSet, get: originalGet } = descriptor;
+      if (!isUndefined(originalGet)) {
+        descriptor.get = this.wrapGetter(originalGet);
+      }
+      if (!isUndefined(originalSet)) {
+        descriptor.set = this.wrapSetter(originalSet);
+      }
     }
-    // Shared utility methods
-    wrapDescriptor(descriptor) {
-        if (hasOwnProperty.call(descriptor, 'value')) {
-            descriptor.value = this.wrapValue(descriptor.value);
-        }
-        else {
-            const { set: originalSet, get: originalGet } = descriptor;
-            if (!isUndefined(originalGet)) {
-                descriptor.get = this.wrapGetter(originalGet);
-            }
-            if (!isUndefined(originalSet)) {
-                descriptor.set = this.wrapSetter(originalSet);
-            }
-        }
-        return descriptor;
+    return descriptor;
+  }
+  copyDescriptorIntoShadowTarget(shadowTarget, key) {
+    const { originalTarget } = this;
+    // Note: a property might get defined multiple times in the shadowTarget
+    //       but it will always be compatible with the previous descriptor
+    //       to preserve the object invariants, which makes these lines safe.
+    const originalDescriptor = getOwnPropertyDescriptor(originalTarget, key);
+    /* istanbul ignore else */
+    if (!isUndefined(originalDescriptor)) {
+      const wrappedDesc = this.wrapDescriptor(originalDescriptor);
+      ObjectDefineProperty(shadowTarget, key, wrappedDesc);
     }
-    copyDescriptorIntoShadowTarget(shadowTarget, key) {
-        const { originalTarget } = this;
-        // Note: a property might get defined multiple times in the shadowTarget
-        //       but it will always be compatible with the previous descriptor
-        //       to preserve the object invariants, which makes these lines safe.
-        const originalDescriptor = getOwnPropertyDescriptor(originalTarget, key);
-        // TODO: it should be impossible for the originalDescriptor to ever be undefined, this `if` can be removed
-        /* istanbul ignore else */
-        if (!isUndefined(originalDescriptor)) {
-            const wrappedDesc = this.wrapDescriptor(originalDescriptor);
-            ObjectDefineProperty(shadowTarget, key, wrappedDesc);
-        }
+  }
+  lockShadowTarget(shadowTarget) {
+    const { originalTarget } = this;
+    const targetKeys = ArrayConcat.call(
+      getOwnPropertyNames(originalTarget),
+      getOwnPropertySymbols(originalTarget)
+    );
+    targetKeys.forEach((key) => {
+      this.copyDescriptorIntoShadowTarget(shadowTarget, key);
+    });
+    const {
+      membrane: { tagPropertyKey }
+    } = this;
+    if (
+      !isUndefined(tagPropertyKey) &&
+      !hasOwnProperty.call(shadowTarget, tagPropertyKey)
+    ) {
+      ObjectDefineProperty(shadowTarget, tagPropertyKey, ObjectCreate(null));
     }
-    lockShadowTarget(shadowTarget) {
-        const { originalTarget } = this;
-        const targetKeys = ArrayConcat.call(getOwnPropertyNames(originalTarget), getOwnPropertySymbols(originalTarget));
-        targetKeys.forEach((key) => {
-            this.copyDescriptorIntoShadowTarget(shadowTarget, key);
-        });
-        const { membrane: { tagPropertyKey }, } = this;
-        if (!isUndefined(tagPropertyKey) && !hasOwnProperty.call(shadowTarget, tagPropertyKey)) {
-            ObjectDefineProperty(shadowTarget, tagPropertyKey, ObjectCreate(null));
-        }
-        preventExtensions(shadowTarget);
+    preventExtensions(shadowTarget);
+  }
+  // Shared Traps
+  /* istanbul ignore next */
+  apply(shadowTarget, thisArg, argArray) {
+    /* No op */
+  }
+  /* istanbul ignore next */
+  construct(shadowTarget, argArray, newTarget) {
+    /* No op */
+  }
+  get(shadowTarget, key) {
+    const {
+      originalTarget,
+      membrane: { valueObserved }
+    } = this;
+    const value = originalTarget[key];
+    valueObserved(originalTarget, key);
+    return this.wrapValue(value);
+  }
+  has(shadowTarget, key) {
+    const {
+      originalTarget,
+      membrane: { tagPropertyKey, valueObserved }
+    } = this;
+    valueObserved(originalTarget, key);
+    // since key is never going to be undefined, and tagPropertyKey might be undefined
+    // we can simply compare them as the second part of the condition.
+    return key in originalTarget || key === tagPropertyKey;
+  }
+  ownKeys(shadowTarget) {
+    const {
+      originalTarget,
+      membrane: { tagPropertyKey }
+    } = this;
+    // if the membrane tag key exists and it is not in the original target, we add it to the keys.
+    const keys =
+      isUndefined(tagPropertyKey) ||
+      hasOwnProperty.call(originalTarget, tagPropertyKey)
+        ? []
+        : [tagPropertyKey];
+    // small perf optimization using push instead of concat to avoid creating an extra array
+    ArrayPush.apply(keys, getOwnPropertyNames(originalTarget));
+    ArrayPush.apply(keys, getOwnPropertySymbols(originalTarget));
+    return keys;
+  }
+  isExtensible(shadowTarget) {
+    const { originalTarget } = this;
+    // optimization to avoid attempting to lock down the shadowTarget multiple times
+    if (!isExtensible(shadowTarget)) {
+      return false; // was already locked down
     }
-    // Shared Traps
-    // TODO: apply() is never called
-    /* istanbul ignore next */
-    apply(shadowTarget, thisArg, argArray) {
-        /* No op */
+    if (!isExtensible(originalTarget)) {
+      this.lockShadowTarget(shadowTarget);
+      return false;
     }
-    // TODO: construct() is never called
-    /* istanbul ignore next */
-    construct(shadowTarget, argArray, newTarget) {
-        /* No op */
+    return true;
+  }
+  getPrototypeOf(shadowTarget) {
+    const { originalTarget } = this;
+    return getPrototypeOf(originalTarget);
+  }
+  getOwnPropertyDescriptor(shadowTarget, key) {
+    const {
+      originalTarget,
+      membrane: { valueObserved, tagPropertyKey }
+    } = this;
+    // keys looked up via getOwnPropertyDescriptor need to be reactive
+    valueObserved(originalTarget, key);
+    let desc = getOwnPropertyDescriptor(originalTarget, key);
+    if (isUndefined(desc)) {
+      if (key !== tagPropertyKey) {
+        return undefined;
+      }
+      // if the key is the membrane tag key, and is not in the original target,
+      // we produce a synthetic descriptor and install it on the shadow target
+      desc = {
+        value: undefined,
+        writable: false,
+        configurable: false,
+        enumerable: false
+      };
+      ObjectDefineProperty(shadowTarget, tagPropertyKey, desc);
+      return desc;
     }
-    get(shadowTarget, key) {
-        const { originalTarget, membrane: { valueObserved }, } = this;
-        const value = originalTarget[key];
-        valueObserved(originalTarget, key);
-        return this.wrapValue(value);
+    if (desc.configurable === false) {
+      // updating the descriptor to non-configurable on the shadow
+      this.copyDescriptorIntoShadowTarget(shadowTarget, key);
     }
-    has(shadowTarget, key) {
-        const { originalTarget, membrane: { tagPropertyKey, valueObserved }, } = this;
-        valueObserved(originalTarget, key);
-        // since key is never going to be undefined, and tagPropertyKey might be undefined
-        // we can simply compare them as the second part of the condition.
-        return key in originalTarget || key === tagPropertyKey;
-    }
-    ownKeys(shadowTarget) {
-        const { originalTarget, membrane: { tagPropertyKey }, } = this;
-        // if the membrane tag key exists and it is not in the original target, we add it to the keys.
-        const keys = isUndefined(tagPropertyKey) || hasOwnProperty.call(originalTarget, tagPropertyKey)
-            ? []
-            : [tagPropertyKey];
-        // small perf optimization using push instead of concat to avoid creating an extra array
-        ArrayPush.apply(keys, getOwnPropertyNames(originalTarget));
-        ArrayPush.apply(keys, getOwnPropertySymbols(originalTarget));
-        return keys;
-    }
-    isExtensible(shadowTarget) {
-        const { originalTarget } = this;
-        // optimization to avoid attempting to lock down the shadowTarget multiple times
-        if (!isExtensible(shadowTarget)) {
-            return false; // was already locked down
-        }
-        if (!isExtensible(originalTarget)) {
-            this.lockShadowTarget(shadowTarget);
-            return false;
-        }
-        return true;
-    }
-    getPrototypeOf(shadowTarget) {
-        const { originalTarget } = this;
-        return getPrototypeOf(originalTarget);
-    }
-    getOwnPropertyDescriptor(shadowTarget, key) {
-        const { originalTarget, membrane: { valueObserved, tagPropertyKey }, } = this;
-        // keys looked up via getOwnPropertyDescriptor need to be reactive
-        valueObserved(originalTarget, key);
-        let desc = getOwnPropertyDescriptor(originalTarget, key);
-        if (isUndefined(desc)) {
-            if (key !== tagPropertyKey) {
-                return undefined;
-            }
-            // if the key is the membrane tag key, and is not in the original target,
-            // we produce a synthetic descriptor and install it on the shadow target
-            desc = { value: undefined, writable: false, configurable: false, enumerable: false };
-            ObjectDefineProperty(shadowTarget, tagPropertyKey, desc);
-            return desc;
-        }
-        if (desc.configurable === false) {
-            // updating the descriptor to non-configurable on the shadow
-            this.copyDescriptorIntoShadowTarget(shadowTarget, key);
-        }
-        // Note: by accessing the descriptor, the key is marked as observed
-        // but access to the value, setter or getter (if available) cannot observe
-        // mutations, just like regular methods, in which case we just do nothing.
-        return this.wrapDescriptor(desc);
-    }
+    // Note: by accessing the descriptor, the key is marked as observed
+    // but access to the value, setter or getter (if available) cannot observe
+    // mutations, just like regular methods, in which case we just do nothing.
+    return this.wrapDescriptor(desc);
+  }
 }

--- a/force-app/lwc/signals/observable-membrane/reactive-handler.js
+++ b/force-app/lwc/signals/observable-membrane/reactive-handler.js
@@ -7,146 +7,167 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { toString, isArray, unwrap, isExtensible, preventExtensions, ObjectDefineProperty, hasOwnProperty, isUndefined, } from './shared';
-import { BaseProxyHandler } from './base-handler';
+import {
+  toString,
+  isArray,
+  unwrap,
+  isExtensible,
+  preventExtensions,
+  ObjectDefineProperty,
+  hasOwnProperty,
+  isUndefined
+} from "./shared";
+import { BaseProxyHandler } from "./base-handler";
 const getterMap = new WeakMap();
 const setterMap = new WeakMap();
 const reverseGetterMap = new WeakMap();
 const reverseSetterMap = new WeakMap();
 export class ReactiveProxyHandler extends BaseProxyHandler {
-    wrapValue(value) {
-        return this.membrane.getProxy(value);
+  wrapValue(value) {
+    return this.membrane.getProxy(value);
+  }
+  wrapGetter(originalGet) {
+    const wrappedGetter = getterMap.get(originalGet);
+    if (!isUndefined(wrappedGetter)) {
+      return wrappedGetter;
     }
-    wrapGetter(originalGet) {
-        const wrappedGetter = getterMap.get(originalGet);
-        if (!isUndefined(wrappedGetter)) {
-            return wrappedGetter;
-        }
-        const handler = this;
-        const get = function () {
-            // invoking the original getter with the original target
-            return handler.wrapValue(originalGet.call(unwrap(this)));
-        };
-        getterMap.set(originalGet, get);
-        reverseGetterMap.set(get, originalGet);
-        return get;
+    const handler = this;
+    const get = function () {
+      // invoking the original getter with the original target
+      return handler.wrapValue(originalGet.call(unwrap(this)));
+    };
+    getterMap.set(originalGet, get);
+    reverseGetterMap.set(get, originalGet);
+    return get;
+  }
+  wrapSetter(originalSet) {
+    const wrappedSetter = setterMap.get(originalSet);
+    if (!isUndefined(wrappedSetter)) {
+      return wrappedSetter;
     }
-    wrapSetter(originalSet) {
-        const wrappedSetter = setterMap.get(originalSet);
-        if (!isUndefined(wrappedSetter)) {
-            return wrappedSetter;
-        }
-        const set = function (v) {
-            // invoking the original setter with the original target
-            originalSet.call(unwrap(this), unwrap(v));
-        };
-        setterMap.set(originalSet, set);
-        reverseSetterMap.set(set, originalSet);
-        return set;
+    const set = function (v) {
+      // invoking the original setter with the original target
+      originalSet.call(unwrap(this), unwrap(v));
+    };
+    setterMap.set(originalSet, set);
+    reverseSetterMap.set(set, originalSet);
+    return set;
+  }
+  unwrapDescriptor(descriptor) {
+    if (hasOwnProperty.call(descriptor, "value")) {
+      // dealing with a data descriptor
+      descriptor.value = unwrap(descriptor.value);
+    } else {
+      const { set, get } = descriptor;
+      if (!isUndefined(get)) {
+        descriptor.get = this.unwrapGetter(get);
+      }
+      if (!isUndefined(set)) {
+        descriptor.set = this.unwrapSetter(set);
+      }
     }
-    unwrapDescriptor(descriptor) {
-        if (hasOwnProperty.call(descriptor, 'value')) {
-            // dealing with a data descriptor
-            descriptor.value = unwrap(descriptor.value);
-        }
-        else {
-            const { set, get } = descriptor;
-            if (!isUndefined(get)) {
-                descriptor.get = this.unwrapGetter(get);
-            }
-            if (!isUndefined(set)) {
-                descriptor.set = this.unwrapSetter(set);
-            }
-        }
-        return descriptor;
+    return descriptor;
+  }
+  unwrapGetter(redGet) {
+    const reverseGetter = reverseGetterMap.get(redGet);
+    if (!isUndefined(reverseGetter)) {
+      return reverseGetter;
     }
-    unwrapGetter(redGet) {
-        const reverseGetter = reverseGetterMap.get(redGet);
-        if (!isUndefined(reverseGetter)) {
-            return reverseGetter;
-        }
-        const handler = this;
-        const get = function () {
-            // invoking the red getter with the proxy of this
-            return unwrap(redGet.call(handler.wrapValue(this)));
-        };
-        getterMap.set(get, redGet);
-        reverseGetterMap.set(redGet, get);
-        return get;
+    const handler = this;
+    const get = function () {
+      // invoking the red getter with the proxy of this
+      return unwrap(redGet.call(handler.wrapValue(this)));
+    };
+    getterMap.set(get, redGet);
+    reverseGetterMap.set(redGet, get);
+    return get;
+  }
+  unwrapSetter(redSet) {
+    const reverseSetter = reverseSetterMap.get(redSet);
+    if (!isUndefined(reverseSetter)) {
+      return reverseSetter;
     }
-    unwrapSetter(redSet) {
-        const reverseSetter = reverseSetterMap.get(redSet);
-        if (!isUndefined(reverseSetter)) {
-            return reverseSetter;
-        }
-        const handler = this;
-        const set = function (v) {
-            // invoking the red setter with the proxy of this
-            redSet.call(handler.wrapValue(this), handler.wrapValue(v));
-        };
-        setterMap.set(set, redSet);
-        reverseSetterMap.set(redSet, set);
-        return set;
+    const handler = this;
+    const set = function (v) {
+      // invoking the red setter with the proxy of this
+      redSet.call(handler.wrapValue(this), handler.wrapValue(v));
+    };
+    setterMap.set(set, redSet);
+    reverseSetterMap.set(redSet, set);
+    return set;
+  }
+  set(shadowTarget, key, value) {
+    const {
+      originalTarget,
+      membrane: { valueMutated }
+    } = this;
+    const oldValue = originalTarget[key];
+    if (oldValue !== value) {
+      originalTarget[key] = value;
+      valueMutated(originalTarget, key);
+    } else if (key === "length" && isArray(originalTarget)) {
+      // fix for issue #236: push will add the new index, and by the time length
+      // is updated, the internal length is already equal to the new length value
+      // therefore, the oldValue is equal to the value. This is the forking logic
+      // to support this use case.
+      valueMutated(originalTarget, key);
     }
-    set(shadowTarget, key, value) {
-        const { originalTarget, membrane: { valueMutated }, } = this;
-        const oldValue = originalTarget[key];
-        if (oldValue !== value) {
-            originalTarget[key] = value;
-            valueMutated(originalTarget, key);
-        }
-        else if (key === 'length' && isArray(originalTarget)) {
-            // fix for issue #236: push will add the new index, and by the time length
-            // is updated, the internal length is already equal to the new length value
-            // therefore, the oldValue is equal to the value. This is the forking logic
-            // to support this use case.
-            valueMutated(originalTarget, key);
-        }
-        return true;
+    return true;
+  }
+  deleteProperty(shadowTarget, key) {
+    const {
+      originalTarget,
+      membrane: { valueMutated }
+    } = this;
+    delete originalTarget[key];
+    valueMutated(originalTarget, key);
+    return true;
+  }
+  setPrototypeOf(shadowTarget, prototype) {
+    throw new Error(
+      `Invalid setPrototypeOf invocation for reactive proxy ${toString(this.originalTarget)}. Prototype of reactive objects cannot be changed.`
+    );
+  }
+  preventExtensions(shadowTarget) {
+    if (isExtensible(shadowTarget)) {
+      const { originalTarget } = this;
+      preventExtensions(originalTarget);
+      // if the originalTarget is a proxy itself, it might reject
+      // the preventExtension call, in which case we should not attempt to lock down
+      // the shadow target.
+      // If a proxy rejects extensions, then calling preventExtensions will throw an error:
+      // https://codepen.io/nolanlawson-the-selector/pen/QWMOjbY
+      /* istanbul ignore if */
+      if (isExtensible(originalTarget)) {
+        return false;
+      }
+      this.lockShadowTarget(shadowTarget);
     }
-    deleteProperty(shadowTarget, key) {
-        const { originalTarget, membrane: { valueMutated }, } = this;
-        delete originalTarget[key];
-        valueMutated(originalTarget, key);
-        return true;
+    return true;
+  }
+  defineProperty(shadowTarget, key, descriptor) {
+    const {
+      originalTarget,
+      membrane: { valueMutated, tagPropertyKey }
+    } = this;
+    if (key === tagPropertyKey && !hasOwnProperty.call(originalTarget, key)) {
+      // To avoid leaking the membrane tag property into the original target, we must
+      // be sure that the original target doesn't have yet.
+      // NOTE: we do not return false here because Object.freeze and equivalent operations
+      // will attempt to set the descriptor to the same value, and expect no to throw. This
+      // is an small compromise for the sake of not having to diff the descriptors.
+      return true;
     }
-    setPrototypeOf(shadowTarget, prototype) {
-        throw new Error(`Invalid setPrototypeOf invocation for reactive proxy ${toString(this.originalTarget)}. Prototype of reactive objects cannot be changed.`);
+    ObjectDefineProperty(
+      originalTarget,
+      key,
+      this.unwrapDescriptor(descriptor)
+    );
+    // intentionally testing if false since it could be undefined as well
+    if (descriptor.configurable === false) {
+      this.copyDescriptorIntoShadowTarget(shadowTarget, key);
     }
-    preventExtensions(shadowTarget) {
-        if (isExtensible(shadowTarget)) {
-            const { originalTarget } = this;
-            preventExtensions(originalTarget);
-            // if the originalTarget is a proxy itself, it might reject
-            // the preventExtension call, in which case we should not attempt to lock down
-            // the shadow target.
-            // TODO: It should not actually be possible to reach this `if` statement.
-            // If a proxy rejects extensions, then calling preventExtensions will throw an error:
-            // https://codepen.io/nolanlawson-the-selector/pen/QWMOjbY
-            /* istanbul ignore if */
-            if (isExtensible(originalTarget)) {
-                return false;
-            }
-            this.lockShadowTarget(shadowTarget);
-        }
-        return true;
-    }
-    defineProperty(shadowTarget, key, descriptor) {
-        const { originalTarget, membrane: { valueMutated, tagPropertyKey }, } = this;
-        if (key === tagPropertyKey && !hasOwnProperty.call(originalTarget, key)) {
-            // To avoid leaking the membrane tag property into the original target, we must
-            // be sure that the original target doesn't have yet.
-            // NOTE: we do not return false here because Object.freeze and equivalent operations
-            // will attempt to set the descriptor to the same value, and expect no to throw. This
-            // is an small compromise for the sake of not having to diff the descriptors.
-            return true;
-        }
-        ObjectDefineProperty(originalTarget, key, this.unwrapDescriptor(descriptor));
-        // intentionally testing if false since it could be undefined as well
-        if (descriptor.configurable === false) {
-            this.copyDescriptorIntoShadowTarget(shadowTarget, key);
-        }
-        valueMutated(originalTarget, key);
-        return true;
-    }
+    valueMutated(originalTarget, key);
+    return true;
+  }
 }

--- a/force-app/lwc/signals/utils.js
+++ b/force-app/lwc/signals/utils.js
@@ -7,11 +7,6 @@ export function debounce(func, delay) {
     debounceTimer = window.setTimeout(() => func(...args), delay);
   };
 }
-// TODO: Uts:
-// TODO: undefined value comparison
-// TODO: simple value comparison
-// TODO: object comparison
-// TODO: array comparison
 export function deepEqual(x, y) {
   const objectKeysFn = Object.keys,
     typeOfX = typeof x,

--- a/force-app/lwc/signals/utils.js
+++ b/force-app/lwc/signals/utils.js
@@ -1,9 +1,23 @@
 export function debounce(func, delay) {
-    let debounceTimer = null;
-    return (...args) => {
-        if (debounceTimer) {
-            clearTimeout(debounceTimer);
-        }
-        debounceTimer = window.setTimeout(() => func(...args), delay);
-    };
+  let debounceTimer = null;
+  return (...args) => {
+    if (debounceTimer) {
+      clearTimeout(debounceTimer);
+    }
+    debounceTimer = window.setTimeout(() => func(...args), delay);
+  };
+}
+// TODO: Uts:
+// TODO: undefined value comparison
+// TODO: simple value comparison
+// TODO: object comparison
+// TODO: array comparison
+export function deepEqual(x, y) {
+  const objectKeysFn = Object.keys,
+    typeOfX = typeof x,
+    typeOfY = typeof y;
+  return x && y && typeOfX === "object" && typeOfX === typeOfY
+    ? objectKeysFn(x).length === objectKeysFn(y).length &&
+        objectKeysFn(x).every((key) => deepEqual(x[key], y[key]))
+    : x === y;
 }

--- a/src/lwc/signals/__tests__/reactivity.test.ts
+++ b/src/lwc/signals/__tests__/reactivity.test.ts
@@ -1,0 +1,114 @@
+import { $effect, $signal } from "../core";
+
+beforeAll(() => {
+  global.console = {
+    ...console,
+    log: jest.fn(), // Mock console.log
+  };
+});
+
+describe("a signal holding a simple value", () => {
+  test("is reactive when their value changes", () => {
+    const signal = $signal(0);
+    let effectAmount = 0;
+    $effect(() => {
+      console.log(signal.value);
+      effectAmount++;
+    });
+    expect(effectAmount).toBe(1);
+
+    signal.value = 1;
+
+    expect(effectAmount).toBe(2);
+  });
+
+  test("is reactive when their value changes multiple times", () => {
+    const signal = $signal(0);
+    let effectAmount = 0;
+    $effect(() => {
+      console.log(signal.value);
+      effectAmount++;
+    });
+    expect(effectAmount).toBe(1);
+
+    signal.value = 1;
+    signal.value = 2;
+    signal.value = 3;
+
+    expect(effectAmount).toBe(4);
+  });
+
+  test("is not reactive when their value is set to the same value", () => {
+    const signal = $signal(0);
+    let effectAmount = 0;
+    $effect(() => {
+      console.log(signal.value);
+      effectAmount++;
+    });
+    expect(effectAmount).toBe(1);
+
+    signal.value = 0;
+
+    expect(effectAmount).toBe(1);
+  });
+});
+
+describe("a signal holding an object", () => {
+  test("is reactive when the object changes", () => {
+    const signal = $signal({ count: 0 });
+    let effectAmount = 0;
+    $effect(() => {
+      console.log(signal.value.count);
+      effectAmount++;
+    });
+    expect(effectAmount).toBe(1);
+
+    signal.value = { count: 1 };
+
+    expect(effectAmount).toBe(2);
+  });
+
+  test("is not reactive when the object is set to the same shape", () => {
+    const signal = $signal({ count: 0 });
+    let effectAmount = 0;
+    $effect(() => {
+      console.log(signal.value.count);
+      effectAmount++;
+    });
+    expect(effectAmount).toBe(1);
+
+    signal.value = { count: 0 };
+
+    expect(effectAmount).toBe(1);
+  });
+});
+
+describe("a signal holding an array", () => {
+  test("is reactive when the array changes", () => {
+    const signal = $signal([0]);
+    let effectAmount = 0;
+    $effect(() => {
+      console.log(signal.value[0]);
+      effectAmount++;
+    });
+    expect(effectAmount).toBe(1);
+
+    signal.value = [1];
+
+    expect(effectAmount).toBe(2);
+  });
+
+  test("is not reactive when the array is set to the same shape", () => {
+    const signal = $signal([0]);
+    let effectAmount = 0;
+    $effect(() => {
+      console.log(signal.value[0]);
+      effectAmount++;
+    });
+    expect(effectAmount).toBe(1);
+
+    signal.value = [0];
+
+    expect(effectAmount).toBe(1);
+  });
+});

--- a/src/lwc/signals/__tests__/resource.test.ts
+++ b/src/lwc/signals/__tests__/resource.test.ts
@@ -429,7 +429,7 @@ test("times called", async () => {
     () => source?.value?.data,
     {
       initialValue: "initial",
-      //fetchWhen: () => source.value.data === "done"
+      fetchWhen: () => source.value.data === "done"
     }
   );
   let timesComputedCalled = 0;

--- a/src/lwc/signals/__tests__/resource.test.ts
+++ b/src/lwc/signals/__tests__/resource.test.ts
@@ -519,35 +519,3 @@ describe("resources", () => {
   });
 });
 
-test("times called", async () => {
-  const sourceAsync = async () => {
-    return "done";
-  };
-
-  const asyncFunction = async (source: string | null) => {
-    return source;
-  };
-
-  const { data: source } = $resource(sourceAsync);
-  $effect(() => console.log("SOURCE", source.value));
-  const { data: resource } = $resource(
-    asyncFunction,
-    () => source?.value?.data,
-    {
-      initialValue: "initial",
-      fetchWhen: () => source.value.data === "done"
-    }
-  );
-  let timesComputedCalled = 0;
-  $computed(() => {
-    timesComputedCalled++;
-    console.log("RESOURCE", resource.value);
-    return resource.value.data;
-  });
-
-  await new Promise(process.nextTick);
-
-  console.log(timesComputedCalled);
-});
-
-// TODO: We want a test that verifies that when fetchWhen never turns to true, it never recalculates a computed (never triggers reactivity)

--- a/src/lwc/signals/__tests__/resource.test.ts
+++ b/src/lwc/signals/__tests__/resource.test.ts
@@ -1,6 +1,9 @@
-import { $resource, $signal } from "../core";
+/* eslint-disable */
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+import { $resource, $signal, $computed, $effect } from "../core";
 
-describe('resources', () => {
+describe("resources", () => {
   test("can can be created by providing an async function", async () => {
     const asyncFunction = async () => {
       return "done";
@@ -194,7 +197,11 @@ describe('resources', () => {
       return "done";
     };
 
-    const asyncReaction = async (newValue: string, __: string | null, mutate: (value: string | null, error?: unknown) => void) => {
+    const asyncReaction = async (
+      newValue: string,
+      __: string | null,
+      mutate: (value: string | null, error?: unknown) => void
+    ) => {
       mutate(`${newValue} - post async success`);
     };
 
@@ -224,7 +231,11 @@ describe('resources', () => {
       return "done";
     };
 
-    const asyncReaction = async (newValue: string, _: string | null, mutate: (value: string | null, error?: unknown) => void) => {
+    const asyncReaction = async (
+      newValue: string,
+      _: string | null,
+      mutate: (value: string | null, error?: unknown) => void
+    ) => {
       mutate(null, "An error occurred");
     };
 
@@ -294,13 +305,16 @@ describe('resources', () => {
     };
 
     const source = $signal("changed");
-    const { data: resource } = $resource(asyncFunction, () => ({
+    const { data: resource } = $resource(
+      asyncFunction,
+      () => ({
         source: source.value
       }),
       {
         initialValue: "initial",
         fetchWhen: () => false
-      });
+      }
+    );
 
     expect(resource.value).toEqual({
       data: "initial",
@@ -323,13 +337,16 @@ describe('resources', () => {
     };
 
     const source = $signal("changed");
-    const { data: resource } = $resource(asyncFunction, () => ({
+    const { data: resource } = $resource(
+      asyncFunction,
+      () => ({
         source: source.value
       }),
       {
         initialValue: "initial",
         fetchWhen: () => true
-      });
+      }
+    );
 
     expect(resource.value).toEqual({
       data: "initial",
@@ -353,13 +370,16 @@ describe('resources', () => {
 
     const flagSignal = $signal(false);
     const source = $signal("changed");
-    const { data: resource } = $resource(asyncFunction, () => ({
+    const { data: resource } = $resource(
+      asyncFunction,
+      () => ({
         source: source.value
       }),
       {
         initialValue: "initial",
         fetchWhen: () => flagSignal.value
-      });
+      }
+    );
 
     expect(resource.value).toEqual({
       data: "initial",
@@ -393,3 +413,33 @@ describe('resources', () => {
   });
 });
 
+test("times called", async () => {
+  const sourceAsync = async () => {
+    return "done";
+  };
+
+  const asyncFunction = async (source: string | null) => {
+    return source;
+  };
+
+  const { data: source } = $resource(sourceAsync);
+  $effect(() => console.log("SOURCE", source.value));
+  const { data: resource } = $resource(
+    asyncFunction,
+    () => source?.value?.data,
+    {
+      initialValue: "initial",
+      //fetchWhen: () => source.value.data === "done"
+    }
+  );
+  let timesComputedCalled = 0;
+  $computed(() => {
+    timesComputedCalled++;
+    console.log("RESOURCE", resource.value);
+    return resource.value.data;
+  });
+
+  await new Promise(process.nextTick);
+
+  console.log(timesComputedCalled);
+});

--- a/src/lwc/signals/__tests__/resource.test.ts
+++ b/src/lwc/signals/__tests__/resource.test.ts
@@ -1,6 +1,3 @@
-/* eslint-disable */
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
 import { $resource, $signal, $computed, $effect } from "../core";
 
 describe("resources", () => {
@@ -364,15 +361,15 @@ describe("resources", () => {
   });
 
   test("fetches when the fetchWhen option is passed reevaluates to true", async () => {
-    const asyncFunction = async (params?: { [key: string]: unknown }) => {
-      return params?.["source"];
+    const asyncFunction = async (params: { [key: string]: unknown }) => {
+      return params["source"];
     };
 
     const flagSignal = $signal(false);
     const source = $signal("changed");
     const { data: resource } = $resource(
       asyncFunction,
-      () => ({
+      (): Record<string, unknown> => ({
         source: source.value
       }),
       {
@@ -443,3 +440,5 @@ test("times called", async () => {
 
   console.log(timesComputedCalled);
 });
+
+// TODO: We want a test that verifies that when fetchWhen never turns to true, it never recalculates a computed (never triggers reactivity)

--- a/src/lwc/signals/__tests__/utils.test.ts
+++ b/src/lwc/signals/__tests__/utils.test.ts
@@ -1,0 +1,50 @@
+import { deepEqual } from "../utils";
+
+describe("deepEqual", () => {
+  test("correctly compares against undefined", () => {
+    expect(deepEqual(undefined, undefined)).toBe(true);
+    expect(deepEqual(undefined, null)).toBe(false);
+    expect(deepEqual(undefined, 1)).toBe(false);
+    expect(deepEqual(undefined, "foo")).toBe(false);
+    expect(deepEqual(undefined, {})).toBe(false);
+    expect(deepEqual(undefined, [])).toBe(false);
+  });
+
+  test("correct compares against nulls", () => {
+    expect(deepEqual(null, null)).toBe(true);
+    expect(deepEqual(null, 1)).toBe(false);
+    expect(deepEqual(null, "foo")).toBe(false);
+    expect(deepEqual(null, {})).toBe(false);
+    expect(deepEqual(null, [])).toBe(false);
+  });
+
+  test("compares simple values", () => {
+    expect(deepEqual(1, 1)).toBe(true);
+    expect(deepEqual(1, 2)).toBe(false);
+    expect(deepEqual("foo", "foo")).toBe(true);
+    expect(deepEqual("foo", "bar")).toBe(false);
+  });
+
+  test("compares objects", () => {
+    expect(deepEqual({}, {})).toBe(true);
+    expect(deepEqual({ foo: "bar" }, { foo: "bar" })).toBe(true);
+    expect(deepEqual({ foo: "bar" }, { foo: "baz" })).toBe(false);
+    expect(deepEqual({ foo: "bar" }, { bar: "baz" })).toBe(false);
+    expect(deepEqual({ foo: "bar" }, { foo: "bar", bar: "baz" })).toBe(false);
+  });
+
+  test("deep compares objects", () => {
+    expect(deepEqual({ foo: { bar: "baz" } }, { foo: { bar: "baz" } })).toBe(true);
+    expect(deepEqual({ foo: { bar: "baz" } }, { foo: { bar: "qux" } })).toBe(false);
+    expect(deepEqual({ foo: { bar: "baz" } }, { foo: { baz: "qux" } })).toBe(false);
+    expect(deepEqual({ foo: { bar: "baz" } }, { foo: { bar: "baz", baz: "qux" } })).toBe(false);
+  });
+
+  test("compares arrays", () => {
+    expect(deepEqual([], [])).toBe(true);
+    expect(deepEqual([1, 2, 3], [1, 2, 3])).toBe(true);
+    expect(deepEqual([1, 2, 3], [1, 2, 4])).toBe(false);
+    expect(deepEqual([1, 2, 3], [1, 2])).toBe(false);
+    expect(deepEqual([1, 2, 3], [1, 2, 3, 4])).toBe(false);
+  });
+});

--- a/src/lwc/signals/core.ts
+++ b/src/lwc/signals/core.ts
@@ -180,9 +180,6 @@ function $signal<T>(
   }
 
   function setter(newValue: T) {
-    // TODO: New unit test for resources since this fixes a bug where it was always reevaluating
-    // TODO: because it was checking for object equality, which in the case of a resource was always false.
-    // TODO: The unit test should fail before, and pass with these changes
     if (deepEqual(newValue, _storageOption.get())) {
       return;
     }

--- a/src/lwc/signals/core.ts
+++ b/src/lwc/signals/core.ts
@@ -1,5 +1,5 @@
 import { useInMemoryStorage, State } from "./use";
-import { debounce } from "./utils";
+import { debounce, deepEqual } from "./utils";
 import { ObservableMembrane } from "./observable-membrane/observable-membrane";
 
 type ReadOnlySignal<T> = {
@@ -180,7 +180,10 @@ function $signal<T>(
   }
 
   function setter(newValue: T) {
-    if (newValue === _storageOption.get()) {
+    // TODO: New unit test for resources since this fixes a bug where it was always reevaluating
+    // TODO: because it was checking for object equality, which in the case of a resource was always false.
+    // TODO: The unit test should fail before, and pass with these changes
+    if (deepEqual(newValue, _storageOption.get())) {
       return;
     }
     trackableState.set(newValue);
@@ -398,7 +401,7 @@ function $resource<T>(
       }
     },
     refetch: async () => {
-      //_isInitialLoad = true;
+      _isInitialLoad = true;
       await execute();
     }
   };

--- a/src/lwc/signals/core.ts
+++ b/src/lwc/signals/core.ts
@@ -347,8 +347,7 @@ function $resource<ReturnType, Params>(
       let data: ReturnType | null = null;
       if (_fetchWhen()) {
         const derivedSource = derivedSourceFn();
-        // TODO: Use deepEquality to compare the derivedSource to previousParams
-        if (!_isInitialLoad && derivedSource === _previousParams) {
+        if (!_isInitialLoad && deepEqual(derivedSource,_previousParams)) {
           // No need to fetch the data again if the params haven't changed
           return;
         }

--- a/src/lwc/signals/observable-membrane/base-handler.ts
+++ b/src/lwc/signals/observable-membrane/base-handler.ts
@@ -63,7 +63,6 @@ export abstract class BaseProxyHandler {
         //       but it will always be compatible with the previous descriptor
         //       to preserve the object invariants, which makes these lines safe.
         const originalDescriptor = getOwnPropertyDescriptor(originalTarget, key);
-        // TODO: it should be impossible for the originalDescriptor to ever be undefined, this `if` can be removed
         /* istanbul ignore else */
         if (!isUndefined(originalDescriptor)) {
             const wrappedDesc = this.wrapDescriptor(originalDescriptor);
@@ -102,12 +101,10 @@ export abstract class BaseProxyHandler {
 
     // Shared Traps
 
-    // TODO: apply() is never called
     /* istanbul ignore next */
     apply(shadowTarget: ShadowTarget, thisArg: any, argArray: any[]) {
         /* No op */
     }
-    // TODO: construct() is never called
     /* istanbul ignore next */
     construct(shadowTarget: ShadowTarget, argArray: any, newTarget?: any): any {
         /* No op */

--- a/src/lwc/signals/observable-membrane/reactive-handler.ts
+++ b/src/lwc/signals/observable-membrane/reactive-handler.ts
@@ -140,7 +140,6 @@ export class ReactiveProxyHandler extends BaseProxyHandler {
             // if the originalTarget is a proxy itself, it might reject
             // the preventExtension call, in which case we should not attempt to lock down
             // the shadow target.
-            // TODO: It should not actually be possible to reach this `if` statement.
             // If a proxy rejects extensions, then calling preventExtensions will throw an error:
             // https://codepen.io/nolanlawson-the-selector/pen/QWMOjbY
             /* istanbul ignore if */

--- a/src/lwc/signals/utils.ts
+++ b/src/lwc/signals/utils.ts
@@ -11,6 +11,12 @@ export function debounce<F extends (...args: unknown[]) => unknown>(
   };
 }
 
+// TODO: Uts:
+// TODO: undefined value comparison
+// TODO: simple value comparison
+// TODO: object comparison
+// TODO: array comparison
+
 export function deepEqual(x: unknown, y: unknown): boolean {
   const objectKeysFn = Object.keys,
     typeOfX = typeof x,

--- a/src/lwc/signals/utils.ts
+++ b/src/lwc/signals/utils.ts
@@ -11,12 +11,6 @@ export function debounce<F extends (...args: unknown[]) => unknown>(
   };
 }
 
-// TODO: Uts:
-// TODO: undefined value comparison
-// TODO: simple value comparison
-// TODO: object comparison
-// TODO: array comparison
-
 export function deepEqual(x: unknown, y: unknown): boolean {
   const objectKeysFn = Object.keys,
     typeOfX = typeof x,

--- a/src/lwc/signals/utils.ts
+++ b/src/lwc/signals/utils.ts
@@ -1,4 +1,7 @@
-export function debounce<F extends (...args: unknown[]) => unknown>(func: F, delay: number): (...args: Parameters<F>) => void {
+export function debounce<F extends (...args: unknown[]) => unknown>(
+  func: F,
+  delay: number
+): (...args: Parameters<F>) => void {
   let debounceTimer: number | null = null;
   return (...args: Parameters<F>) => {
     if (debounceTimer) {
@@ -6,4 +9,14 @@ export function debounce<F extends (...args: unknown[]) => unknown>(func: F, del
     }
     debounceTimer = window.setTimeout(() => func(...args), delay);
   };
+}
+
+export function deepEqual(x: unknown, y: unknown): boolean {
+  const objectKeysFn = Object.keys,
+    typeOfX = typeof x,
+    typeOfY = typeof y;
+  return x && y && typeOfX === "object" && typeOfX === typeOfY
+    ? objectKeysFn(x).length === objectKeysFn(y).length &&
+        objectKeysFn(x).every((key) => deepEqual((x as Record<string, unknown>)[key], (y as Record<string, unknown>)[key]))
+    : x === y;
 }


### PR DESCRIPTION
Introduces improvements to the reactive cycles of signals and resources.

* Previously, signals holding objects were not correct evaluated for changes, causing unnecessary notifications to observers. Now, even if the signal holds an object, the object is checked for deep equality of its properties and values (as opposed to checking for object identity).
* Resource reactive cycles have also been improved to avoid unnecessary notifications.
  * A resource's source function is never evaluated unless fetchWhen is true
  * The deepCheck evaluation done for signals is also now done for resource source functions, avoiding unnecessary re-evaluation when these return an object
