### PR TITLE
Error handling and circular dependency management.

### DIFF
--- a/force-app/lwc/signals/core.js
+++ b/force-app/lwc/signals/core.js
@@ -6,6 +6,10 @@ const context = [];
 function _getCurrentObserver() {
   return context[context.length - 1];
 }
+const UNSET = Symbol("UNSET");
+const COMPUTING = Symbol("COMPUTING");
+const ERRORED = Symbol("ERRORED");
+const READY = Symbol("READY");
 /**
  * Creates a new effect that will be executed immediately and whenever
  * any of the signals it reads from change.
@@ -26,15 +30,33 @@ function _getCurrentObserver() {
  * @param fn The function to execute
  */
 function $effect(fn) {
+  const effectNode = {
+    error: null,
+    state: UNSET
+  };
   const execute = () => {
+    if (effectNode.state === COMPUTING) {
+      throw new Error("Circular dependency detected");
+    }
     context.push(execute);
     try {
+      effectNode.state = COMPUTING;
       fn();
+      effectNode.error = null;
+      effectNode.state = READY;
     } finally {
       context.pop();
     }
   };
   execute();
+}
+function computedGetter(node) {
+  if (node.state === ERRORED) {
+    console.log("throwing error", node.error);
+    throw node.error;
+  }
+  console.log("all good");
+  return node.signal.readOnly;
 }
 /**
  * Creates a new computed value that will be updated whenever the signals
@@ -52,13 +74,26 @@ function $effect(fn) {
  * @param fn The function that returns the computed value.
  */
 function $computed(fn) {
-  // The initial value is undefined, as it will be computed
-  // when the effect runs for the first time
-  const computedSignal = $signal(undefined);
+  const computedNode = {
+    signal: $signal(undefined),
+    error: null,
+    state: UNSET
+  };
   $effect(() => {
-    computedSignal.value = fn();
+    if (computedNode.state === COMPUTING) {
+      throw new Error("Circular dependency detected");
+    }
+    try {
+      computedNode.state = COMPUTING;
+      computedNode.signal.value = fn();
+      computedNode.error = null;
+      computedNode.state = READY;
+    } catch (error) {
+      computedNode.state = ERRORED;
+      computedNode.error = error;
+    }
   });
-  return computedSignal.readOnly;
+  return computedGetter(computedNode);
 }
 class UntrackedState {
   constructor(value) {

--- a/src/lwc/signals/__tests__/computed.test.ts
+++ b/src/lwc/signals/__tests__/computed.test.ts
@@ -1,4 +1,4 @@
-import { $computed, $effect, $signal } from "../core";
+import { $computed, $signal } from "../core";
 
 describe("computed values", () => {
   test("can be created from a source signal", () => {

--- a/src/lwc/signals/__tests__/computed.test.ts
+++ b/src/lwc/signals/__tests__/computed.test.ts
@@ -1,4 +1,4 @@
-import { $computed, $signal } from "../core";
+import { $computed, $effect, $signal } from "../core";
 
 describe("computed values", () => {
   test("can be created from a source signal", () => {
@@ -46,13 +46,4 @@ describe("computed values", () => {
     expect(computed.value).toBe(2);
     expect(anotherComputed.value).toBe(4);
   });
-
-  // test("throws an error when a circular dependency is detected", () => {
-  //   const signal = $signal(0);
-  //   const computed = $computed(() => signal.value * 2);
-  //   const computed2 = $computed(() => computed.value + 1);
-  //
-  //   // TODO
-  //
-  // });
 });

--- a/src/lwc/signals/__tests__/computed.test.ts
+++ b/src/lwc/signals/__tests__/computed.test.ts
@@ -46,4 +46,13 @@ describe("computed values", () => {
     expect(computed.value).toBe(2);
     expect(anotherComputed.value).toBe(4);
   });
+
+  // test("throws an error when a circular dependency is detected", () => {
+  //   const signal = $signal(0);
+  //   const computed = $computed(() => signal.value * 2);
+  //   const computed2 = $computed(() => computed.value + 1);
+  //
+  //   // TODO
+  //
+  // });
 });

--- a/src/lwc/signals/__tests__/effect.test.ts
+++ b/src/lwc/signals/__tests__/effect.test.ts
@@ -14,4 +14,13 @@ describe("effects", () => {
     signal.value = 1;
     expect(effectTracker).toBe(1);
   });
+
+  test("throw an error when a circular dependency is detected", () => {
+    expect(() => {
+      const signal = $signal(0);
+      $effect(() => {
+        signal.value = signal.value++;
+      });
+    }).toThrow();
+  });
 });


### PR DESCRIPTION
The following changes and improvements were introduced:

* Computed and effects now track if their internal state during their execution. They might be "computing", have an "error" or be "ready". 
* When a circular dependency is detected, an exception is thrown instead of trying the computation, to avoid infinite loops from happening.
* When an error occurs during an execution of a computed value, the `computed` goes into an error state, which it keeps until recomputation is done and fixes the issue. This fixes potential infinite loops when executing computed code with errors. Reading a `computed` in an error state surfaces the error