### PR TITLE
Improved error handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "develop"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "develop"]
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -8,9 +8,8 @@ A simple yet powerful reactive state management solution for Lightning Web Compo
 ![Version](https://img.shields.io/badge/version-1.1.1-blue)
 
 Inspired by the Signals technology behind SolidJs, Preact, Svelte 5 Runes and the Vue 3 Composition API, LWC Signals is
-a
-reactive signals for Lightning Web Components that allows you to create reactive data signals
-that can be used to share state between components.
+a reactive signals implementation for Lightning Web Components.
+It allows you to create reactive data signals that can be used to share up-to-date state between components.
 
 It features:
 
@@ -161,7 +160,7 @@ export default class Display extends LightningElement {
     <img src="./doc-assets/counter-example.gif" alt="Counter Example" />
 </p>
 
-### Stacking computed values
+#### Stacking computed values
 
 You can also stack computed values to create more complex reactive values that derive from each other
 
@@ -175,6 +174,113 @@ export const counterPlusTwo = $computed(() => counterPlusOne.value + 1);
 ```
 
 Because `$computed` values return a signal, you can use them as you would use any other signal.
+
+### `$effect`
+
+You can also use the `$effect` function to create a side effect that depends on a signal.
+
+Let's say you want to keep a log of the changes in the `counter` signal.
+
+```javascript
+import { $signal, $effect } from "c/signals";
+
+export const counter = $signal(0);
+
+$effect(() => console.log(counter.value));
+```
+
+> ❗ DO NOT use `$effect` to update the signal value, as it will create an infinite loop.
+
+## Error Handling
+
+When unhandled errors occur in a `computed` or `effect`, by default, the error will be logged to the console through
+a `console.error` call, and then the error will be rethrown.
+
+If you wish to know which `computed` or `effect` caused the error, you can pass a second argument to the `computed` or
+`effect` with a unique identifier.
+
+```javascript
+$computed(
+  () => {
+    signal.value;
+    throw new Error("error");
+  },
+  { identifier: "test-identifier" }
+);
+
+$effect(
+  () => {
+    signal.value;
+    throw new Error("error");
+  },
+  { identifier: "test-identifier" }
+);
+```
+
+This value will be used only for debugging purposes, and does not affect the functionality otherwise.
+
+In this example, the test-identifier string will appear as part of the console.error message.
+
+### Custom Error Handlers
+
+Both computed and effect signals can receive a custom `errorHandler` property,
+that allows developers to completely override the default functionality that logs and rethrows the error.
+
+#### Effect handlers
+
+For `$effect` handlers, you can pass a function with the following shape:
+
+```typescript
+(error: any) => void
+```
+
+The thrown error will be passed as an argument, and nothing should be returned.
+
+Example:
+
+```javascript
+function customErrorHandlerFn(error) {
+  // custom logic or logging or rethrowing here
+}
+
+$effect(
+  () => {
+    throw new Error("test");
+  },
+  {
+    errorHandler: customErrorHandlerFn
+  }
+);
+```
+
+#### Computed handlers
+
+For `$computed` handlers, you can pass a function with the following shape:
+
+```typescript
+(error: unknown) => T | undefined;
+```
+
+Where you can return nothing, or a value of type `T`, which should be of the same type as the computed value itself.
+This allows you to provide a "fallback" value, that the computed value will receive in case of errors.
+
+Example
+
+```javascript
+function customErrorHandlerFn(error) {
+  // custom logic or logging or rethrowing here
+  return "fallback value";
+}
+
+$computed(
+  () => {
+    throw new Error("test");
+  },
+  {
+    errorHandler: customErrorHandlerFn
+  }
+);
+```
 
 ## Tracking objects and arrays
 
@@ -200,8 +306,8 @@ console.log(computedFromObj.value); // 4
 
 ## Reacting to multiple signals
 
-You can also use multiple signals in a single `computed` and react to changes in any of them.
-This gives you the ability to create complex reactive values that depend on multiple data sources
+You can also use multiple signals in a single `computed` or `effect` and react to changes in any of them.
+This allows you to create complex reactive values that depend on multiple data sources
 without having to track each one independently.
 
 > 👀 You can find the full working code for the following example in the `examples`
@@ -295,22 +401,6 @@ export default class BusinessCard extends LightningElement {
 
 > ❗ Notice that we are using a property instead of a getter in the `$computed` callback function, because
 > we need to reassign the value to `this.contactInfo` to trigger the reactivity, as it is a complex object.
-
-### `$effect`
-
-You can also use the `$effect` function to create a side effect that depends on a signal.
-
-Let's say you want to keep a log of the changes in the `counter` signal.
-
-```javascript
-import { $signal, $effect } from "c/signals";
-
-export const counter = $signal(0);
-
-$effect(() => console.log(counter.value));
-```
-
-> ❗ DO NOT use `$effect` to update the signal value, as it will create an infinite loop.
 
 ## Communicating with Apex data and other asynchronous operations
 
@@ -817,7 +907,8 @@ The following storage helpers are available by default:
   if using a platform event, this will contain the fields of the platform event.
 
   - The `options` (optional) parameter is an object that can contain the following properties (all of them optional):
-    - `replayId` The replay ID to start from, defaults to -1. When -2 is passed, it will replay from the last saved event.
+    - `replayId` The replay ID to start from, defaults to -1. When -2 is passed, it will replay from the last saved
+      event.
     - `onSubscribe` A callback function called when the subscription is successful.
     - `onError` A callback function called when an error response is received from the server for
       handshake, connect, subscribe, and unsubscribe meta channels.

--- a/examples/demo-signals/lwc/demoSignals/demoSignals.js
+++ b/examples/demo-signals/lwc/demoSignals/demoSignals.js
@@ -3,3 +3,4 @@ export * from "./contact-info";
 export * from "./apex-fetcher";
 export * from "./shopping-cart";
 export * from "./chat-data-source";
+export * from "./error-handler";

--- a/examples/demo-signals/lwc/demoSignals/error-handler.js
+++ b/examples/demo-signals/lwc/demoSignals/error-handler.js
@@ -8,10 +8,21 @@ $computed(
     throw new Error("An error occurred during a computation");
   },
   {
-    identifier: "computed-with-error"
+    errorHandler: (error) => {
+      console.error("error thrown from computed", error);
+      // Allows for a fallback value to be returned when an error occurs.
+      return 0;
+    }
   }
 );
 
-$effect(() => {
-  throw new Error("An error occurred during an effect");
-});
+$effect(
+  () => {
+    throw new Error("An error occurred during an effect");
+  },
+  {
+    errorHandler: (error) => {
+      console.error("error thrown from effect", error);
+    }
+  }
+);

--- a/examples/demo-signals/lwc/demoSignals/error-handler.js
+++ b/examples/demo-signals/lwc/demoSignals/error-handler.js
@@ -1,0 +1,12 @@
+import { $signal, $computed, $effect } from "c/signals";
+
+const anySignal = $signal(0);
+
+$computed(() => {
+  anySignal.value;
+  throw new Error("An error occurred during a computation");
+});
+
+$effect(() => {
+  throw new Error("An error occurred during an effect");
+});

--- a/examples/demo-signals/lwc/demoSignals/error-handler.js
+++ b/examples/demo-signals/lwc/demoSignals/error-handler.js
@@ -2,10 +2,15 @@ import { $signal, $computed, $effect } from "c/signals";
 
 const anySignal = $signal(0);
 
-$computed(() => {
-  anySignal.value;
-  throw new Error("An error occurred during a computation");
-});
+$computed(
+  () => {
+    anySignal.value;
+    throw new Error("An error occurred during a computation");
+  },
+  {
+    identifier: "computed-with-error"
+  }
+);
 
 $effect(() => {
   throw new Error("An error occurred during an effect");

--- a/force-app/lwc/signals/core.js
+++ b/force-app/lwc/signals/core.js
@@ -11,7 +11,8 @@ const COMPUTING = Symbol("COMPUTING");
 const ERRORED = Symbol("ERRORED");
 const READY = Symbol("READY");
 const defaultEffectProps = {
-  _fromComputed: false
+  _fromComputed: false,
+  identifier: null
 };
 /**
  * Creates a new effect that will be executed immediately and whenever
@@ -60,7 +61,9 @@ function $effect(fn, props) {
   execute();
 }
 function handleEffectError(error, props) {
-  const source = props._fromComputed ? "Computed" : "Effect";
+  const source =
+    (props._fromComputed ? "Computed" : "Effect") +
+    (props.identifier ? ` (${props.identifier})` : "");
   const errorMessage = `An error occurred in a ${source} function`;
   console.error(errorMessage, error);
   throw error;
@@ -79,13 +82,15 @@ function handleEffectError(error, props) {
  * ```
  *
  * @param fn The function that returns the computed value.
+ * @param props Options to configure the computed value.
  */
-function $computed(fn) {
+function $computed(fn, props) {
   const computedSignal = $signal(undefined, {
     track: true
   });
   $effect(() => (computedSignal.value = fn()), {
-    _fromComputed: true
+    _fromComputed: true,
+    identifier: props?.identifier ?? null
   });
   return computedSignal.readOnly;
 }

--- a/force-app/lwc/signals/core.js
+++ b/force-app/lwc/signals/core.js
@@ -44,17 +44,16 @@ function $effect(fn) {
       fn();
       effectNode.error = null;
       effectNode.state = READY;
+    } catch (error) {
+      console.error(error);
+      effectNode.state = ERRORED;
+      effectNode.error = error;
+      throw error;
     } finally {
       context.pop();
     }
   };
   execute();
-}
-function computedGetter(node) {
-  if (node.state === ERRORED) {
-    throw node.error;
-  }
-  return node.signal.readOnly;
 }
 /**
  * Creates a new computed value that will be updated whenever the signals
@@ -72,26 +71,9 @@ function computedGetter(node) {
  * @param fn The function that returns the computed value.
  */
 function $computed(fn) {
-  const computedNode = {
-    signal: $signal(undefined),
-    error: null,
-    state: UNSET
-  };
-  $effect(() => {
-    if (computedNode.state === COMPUTING) {
-      throw new Error("Circular dependency detected");
-    }
-    try {
-      computedNode.state = COMPUTING;
-      computedNode.signal.value = fn();
-      computedNode.error = null;
-      computedNode.state = READY;
-    } catch (error) {
-      computedNode.state = ERRORED;
-      computedNode.error = error;
-    }
-  });
-  return computedGetter(computedNode);
+  const computedSignal = $signal(undefined, { track: true });
+  $effect(() => (computedSignal.value = fn()));
+  return computedSignal.readOnly;
 }
 class UntrackedState {
   constructor(value) {
@@ -102,6 +84,9 @@ class UntrackedState {
   }
   set(value) {
     this._value = value;
+  }
+  forceUpdate() {
+    return false;
   }
 }
 class TrackedState {
@@ -118,6 +103,9 @@ class TrackedState {
   }
   set(value) {
     this._value = this._membrane.getProxy(value);
+  }
+  forceUpdate() {
+    return true;
   }
 }
 /**
@@ -163,7 +151,10 @@ function $signal(value, options) {
     return _storageOption.get();
   }
   function setter(newValue) {
-    if (isEqual(newValue, _storageOption.get())) {
+    if (
+      !trackableState.forceUpdate() &&
+      isEqual(newValue, _storageOption.get())
+    ) {
       return;
     }
     trackableState.set(newValue);
@@ -192,16 +183,17 @@ function $signal(value, options) {
         setter(newValue);
       }
     },
+    brand: Symbol.for("lwc-signals"),
     readOnly: {
       get value() {
         return getter();
       }
     }
   };
-  // We don't want to expose the `get` and `set` methods, so
-  // remove before returning
   delete returnValue.get;
   delete returnValue.set;
+  delete returnValue.registerOnChange;
+  delete returnValue.unsubscribe;
   return returnValue;
 }
 function $resource(fn, source, options) {

--- a/force-app/lwc/signals/core.js
+++ b/force-app/lwc/signals/core.js
@@ -90,10 +90,26 @@ function $computed(fn, props) {
   const computedSignal = $signal(undefined, {
     track: true
   });
-  $effect(() => (computedSignal.value = fn()), {
-    _fromComputed: true,
-    identifier: props?.identifier ?? null
-  });
+  $effect(
+    () => {
+      if (props?.errorHandler) {
+        // If this computed has a custom errorHandler, then error
+        // handling occurs in the computed function itself.
+        try {
+          computedSignal.value = fn();
+        } catch (error) {
+          computedSignal.value = props.errorHandler(error);
+        }
+      } else {
+        // Otherwise, the error handling is done in the $effect
+        computedSignal.value = fn();
+      }
+    },
+    {
+      _fromComputed: true,
+      identifier: props?.identifier ?? null
+    }
+  );
   return computedSignal.readOnly;
 }
 class UntrackedState {

--- a/force-app/lwc/signals/core.js
+++ b/force-app/lwc/signals/core.js
@@ -53,7 +53,9 @@ function $effect(fn, props) {
     } catch (error) {
       effectNode.state = ERRORED;
       effectNode.error = error;
-      handleEffectError(error, _props);
+      _props.errorHandler
+        ? _props.errorHandler(error)
+        : handleEffectError(error, _props);
     } finally {
       context.pop();
     }

--- a/src/lwc/signals/__tests__/computed.test.ts
+++ b/src/lwc/signals/__tests__/computed.test.ts
@@ -102,4 +102,30 @@ describe("computed values", () => {
 
     spy.mockRestore();
   });
+
+  test("allow for errors to be handled through a custom function", () => {
+    const customErrorHandlerFn = jest.fn() as (error: unknown) => void;
+
+    $computed(() => {
+      throw new Error("test");
+    }, {
+      errorHandler: customErrorHandlerFn
+    });
+
+    expect(customErrorHandlerFn).toHaveBeenCalled();
+  });
+
+  test("allow for errors to be handled through a custom function and return a fallback value", () => {
+    function customErrorHandlerFn() {
+      return "fallback";
+    }
+
+    const computed = $computed(() => {
+      throw new Error("test");
+    }, {
+      errorHandler: customErrorHandlerFn
+    });
+
+    expect(computed.value).toBe("fallback");
+  });
 });

--- a/src/lwc/signals/__tests__/computed.test.ts
+++ b/src/lwc/signals/__tests__/computed.test.ts
@@ -57,4 +57,32 @@ describe("computed values", () => {
     signal.value.a = 1;
     expect(spy).toHaveBeenCalled();
   });
+
+  test("throw an error when a circular dependency is detected", () => {
+    console.error = jest.fn();
+    expect(() => {
+      const signal = $signal(0);
+      $computed(() => {
+        signal.value = signal.value++;
+        return signal.value;
+      });
+    }).toThrow();
+  });
+
+  test("console errors when a computed throws an error", () => {
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const signal = $signal(0);
+      $computed(() => {
+        signal.value;
+        throw new Error("error");
+      });
+      signal.value = 1;
+    } catch (e) {
+      expect(spy).toHaveBeenCalled();
+    }
+
+    spy.mockRestore();
+  });
 });

--- a/src/lwc/signals/__tests__/computed.test.ts
+++ b/src/lwc/signals/__tests__/computed.test.ts
@@ -85,4 +85,21 @@ describe("computed values", () => {
 
     spy.mockRestore();
   });
+
+  test("console errors with an identifier when one was provided", () => {
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const signal = $signal(0);
+      $computed(() => {
+        signal.value;
+        throw new Error("error");
+      }, { identifier: "test-identifier" });
+      signal.value = 1;
+    } catch (e) {
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining("test-identifier"), expect.any(Error));
+    }
+
+    spy.mockRestore();
+  });
 });

--- a/src/lwc/signals/__tests__/effect.test.ts
+++ b/src/lwc/signals/__tests__/effect.test.ts
@@ -31,11 +31,24 @@ describe("effects", () => {
   });
 
   test("throw an error when a circular dependency is detected", () => {
+    console.error = jest.fn();
     expect(() => {
       const signal = $signal(0);
       $effect(() => {
         signal.value = signal.value++;
       });
     }).toThrow();
+  });
+
+  test("console errors when an effect throws an error", () => {
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      $effect(() => {
+        throw new Error("test");
+      });
+    } catch (error) {
+      expect(spy).toHaveBeenCalled();
+    }
+    spy.mockRestore();
   });
 });

--- a/src/lwc/signals/__tests__/effect.test.ts
+++ b/src/lwc/signals/__tests__/effect.test.ts
@@ -51,4 +51,15 @@ describe("effects", () => {
     }
     spy.mockRestore();
   });
+
+  test("allow for errors to be handled through a custom function", () => {
+    const customErrorHandlerFn = jest.fn();
+    $effect(() => {
+      throw new Error("test");
+    }, {
+      errorHandler: customErrorHandlerFn
+    });
+
+    expect(customErrorHandlerFn).toHaveBeenCalled();
+  });
 });

--- a/src/lwc/signals/core.ts
+++ b/src/lwc/signals/core.ts
@@ -32,10 +32,12 @@ interface EffectNode {
 
 type EffectProps = {
   _fromComputed: boolean;
+  identifier: string | null;
 };
 
 const defaultEffectProps: EffectProps = {
-  _fromComputed: false
+  _fromComputed: false,
+  identifier: null
 };
 
 /**
@@ -89,13 +91,16 @@ function $effect(fn: VoidFunction, props?: Partial<EffectProps>): void {
 }
 
 function handleEffectError(error: unknown, props: EffectProps) {
-  const source = props._fromComputed ? "Computed" : "Effect";
+  const source = (props._fromComputed ? "Computed" : "Effect") + (props.identifier ? ` (${props.identifier})` : "");
   const errorMessage = `An error occurred in a ${source} function`;
   console.error(errorMessage, error);
   throw error;
 }
 
 type ComputedFunction<T> = () => T;
+type ComputedProps = {
+  identifier: string | null;
+}
 
 /**
  * Creates a new computed value that will be updated whenever the signals
@@ -111,13 +116,15 @@ type ComputedFunction<T> = () => T;
  * ```
  *
  * @param fn The function that returns the computed value.
+ * @param props Options to configure the computed value.
  */
-function $computed<T>(fn: ComputedFunction<T>): ReadOnlySignal<T> {
+function $computed<T>(fn: ComputedFunction<T>, props?: ComputedProps): ReadOnlySignal<T> {
   const computedSignal: Signal<T | undefined> = $signal(undefined, {
     track: true
   });
   $effect(() => (computedSignal.value = fn()), {
-    _fromComputed: true
+    _fromComputed: true,
+    identifier: props?.identifier ?? null
   });
   return computedSignal.readOnly as ReadOnlySignal<T>;
 }


### PR DESCRIPTION
Improves the error handling experience by providing a couple of features to debug and/or modify the way errors are handled when issues occur in a `$computed` or an `$effect`

## Errors are now surfaced as a `console.error` by default

Before, when an error occurred in a computed or an effect, the exception was rethrown. The issue is that Salesforce handles these exceptions differently based on the environment. For example, LWC debugging might be on/off, which changes how errors are surfaced, and errors are handled differently in LWR templates, where the user is redirected to the `error` page.

To improve this experience, when an error occurs in either a computed or effect function, a console.error will be called so that the error is easier to detect (the exception will still be retrhwon after logging).

## Computed and effects can now have an "identifier" for logging purposes.

Following on the previous improvement, if you want to pinpoint exactly which effect or which computed values is the one throwing the exception, a new `identifier` property was introduced. This is only for debugging purposes, and does not affect the functionality otherwise. 

Example

```
      $computed(() => {
        signal.value;
        throw new Error("error");
      }, { identifier: "test-identifier" });
```

In this example, the `test-identifier` string will appear as part of the `console.error` message.

## Computed and effects can now have custom error handlers

Both computed and effect signals can receive a custom `errorHandler` property, that allows developers to **completely override** the default functionality that logs and rethrows the error.

### Effect handlers

For `$effect` handlers, you can pass a function with the following shape:

```
(error) => void
```

The thrown error will be passed as an argument, and nothing should be returned.

Example:

```
    function customErrorHandlerFn(error) {
      // custom logic or logging or rethrowing here
    }
    $effect(() => {
      throw new Error("test");
    }, {
      errorHandler: customErrorHandlerFn
    });
```

### Computed handlers

For `$computed` handlers, you can pass a function with the following shape:

```
(error: unknown) => T | undefined
```

Where you can return nothing, or a value of type `T`, which should be of the same type as the computed value itself. This allows you to provide a "fallback" value, that the computed value will receive in case of errors.

Example

```
    function customErrorHandlerFn(error) {
      // custom logic or logging or rethrowing here
     return "fallback value";
    }
    $computed(() => {
      throw new Error("test");
    }, {
      errorHandler: customErrorHandlerFn
    });
```