### PR TITLE
Minor release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "develop"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "develop"]
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -191,6 +191,33 @@ $effect(() => console.log(counter.value));
 
 > ❗ DO NOT use `$effect` to update the signal value, as it will create an infinite loop.
 
+## Peeking at the signal value
+
+If the rare case that you have an effect that needs to read of a signal without subscribing to it, you can
+use the signal's `peek` function to read the value.
+
+```javascript
+import { $signal, $effect } from "c/signals";
+
+const counter = $signal(0);
+
+$effect(() => console.log(counter.peek()));
+```
+
+This can be useful when you need to update the value of a signal based on its current value, but you want
+to avoid causing a circular dependency.
+
+```javascript
+const counter = $signal(0);
+$effect(() => {
+  // Without peeking, this kind of operation would cause a circular dependency.
+  counter.value = counter.peek() + 1;
+});
+```
+
+Note that you should use this feature sparingly, as it can lead to bugs that are hard to track down.
+The preferred way of reading a signal is through the `signal.value`.
+
 ## Error Handling
 
 When unhandled errors occur in a `computed` or `effect`, by default, the error will be logged to the console through

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ In this example, the test-identifier string will appear as part of the console.e
 
 ### Custom Error Handlers
 
-Both computed and effect signals can receive a custom `errorHandler` property,
+Both computed and effect signals can receive a custom `onError` property,
 that allows developers to completely override the default functionality that logs and rethrows the error.
 
 #### Effect handlers
@@ -258,10 +258,11 @@ that allows developers to completely override the default functionality that log
 For `$effect` handlers, you can pass a function with the following shape:
 
 ```typescript
-(error: any) => void
+(error: any, options: { identifier: string | symbol }) => void
 ```
 
-The thrown error will be passed as an argument, and nothing should be returned.
+The function will receive the thrown error as the first argument, and an object with the identifier as the second.
+It should not return anything.
 
 Example:
 
@@ -275,7 +276,7 @@ $effect(
     throw new Error("test");
   },
   {
-    errorHandler: customErrorHandlerFn
+    onError: customErrorHandlerFn
   }
 );
 ```
@@ -285,16 +286,22 @@ $effect(
 For `$computed` handlers, you can pass a function with the following shape:
 
 ```typescript
-(error: unknown) => T | undefined;
+(error: unknown, previousValue: T, options: { identifier: string | symbol }) =>
+  T | undefined;
 ```
 
 Where you can return nothing, or a value of type `T`, which should be of the same type as the computed value itself.
 This allows you to provide a "fallback" value, that the computed value will receive in case of errors.
 
+As a second argument, you will receive the previous value of the computed signal, which can be useful to provide a
+fallback value based on the previous value.
+
+The third argument is an object with the received identifier.
+
 Example
 
 ```javascript
-function customErrorHandlerFn(error) {
+function customErrorHandlerFn(error, _previousValue, _options) {
   // custom logic or logging or rethrowing here
   return "fallback value";
 }
@@ -304,7 +311,7 @@ $computed(
     throw new Error("test");
   },
   {
-    errorHandler: customErrorHandlerFn
+    onError: customErrorHandlerFn
   }
 );
 ```

--- a/README.md
+++ b/README.md
@@ -258,10 +258,11 @@ that allows developers to completely override the default functionality that log
 For `$effect` handlers, you can pass a function with the following shape:
 
 ```typescript
-(error: any) => void
+(error: any, options: { identifier: string | symbol }) => void
 ```
 
-The thrown error will be passed as an argument, and nothing should be returned.
+The function will receive the thrown error as the first argument, and an object with the identifier as the second.
+It should not return anything.
 
 Example:
 
@@ -285,16 +286,22 @@ $effect(
 For `$computed` handlers, you can pass a function with the following shape:
 
 ```typescript
-(error: unknown) => T | undefined;
+(error: unknown, previousValue: T, options: { identifier: string | symbol }) =>
+  T | undefined;
 ```
 
 Where you can return nothing, or a value of type `T`, which should be of the same type as the computed value itself.
 This allows you to provide a "fallback" value, that the computed value will receive in case of errors.
 
+As a second argument, you will receive the previous value of the computed signal, which can be useful to provide a
+fallback value based on the previous value.
+
+The third argument is an object with the received identifier.
+
 Example
 
 ```javascript
-function customErrorHandlerFn(error) {
+function customErrorHandlerFn(error, _previousValue, _options) {
   // custom logic or logging or rethrowing here
   return "fallback value";
 }

--- a/README.md
+++ b/README.md
@@ -8,9 +8,8 @@ A simple yet powerful reactive state management solution for Lightning Web Compo
 ![Version](https://img.shields.io/badge/version-1.1.1-blue)
 
 Inspired by the Signals technology behind SolidJs, Preact, Svelte 5 Runes and the Vue 3 Composition API, LWC Signals is
-a
-reactive signals for Lightning Web Components that allows you to create reactive data signals
-that can be used to share state between components.
+a reactive signals implementation for Lightning Web Components.
+It allows you to create reactive data signals that can be used to share up-to-date state between components.
 
 It features:
 
@@ -161,7 +160,7 @@ export default class Display extends LightningElement {
     <img src="./doc-assets/counter-example.gif" alt="Counter Example" />
 </p>
 
-### Stacking computed values
+#### Stacking computed values
 
 You can also stack computed values to create more complex reactive values that derive from each other
 
@@ -175,6 +174,113 @@ export const counterPlusTwo = $computed(() => counterPlusOne.value + 1);
 ```
 
 Because `$computed` values return a signal, you can use them as you would use any other signal.
+
+### `$effect`
+
+You can also use the `$effect` function to create a side effect that depends on a signal.
+
+Let's say you want to keep a log of the changes in the `counter` signal.
+
+```javascript
+import { $signal, $effect } from "c/signals";
+
+export const counter = $signal(0);
+
+$effect(() => console.log(counter.value));
+```
+
+> ❗ DO NOT use `$effect` to update the signal value, as it will create an infinite loop.
+
+## Error Handling
+
+When unhandled errors occur in a `computed` or `effect`, by default, the error will be logged to the console through
+a `console.error` call, and then the error will be rethrown.
+
+If you wish to know which `computed` or `effect` caused the error, you can pass a second argument to the `computed` or
+`effect` with a unique identifier.
+
+```javascript
+$computed(
+  () => {
+    signal.value;
+    throw new Error("error");
+  },
+  { identifier: "test-identifier" }
+);
+
+$effect(
+  () => {
+    signal.value;
+    throw new Error("error");
+  },
+  { identifier: "test-identifier" }
+);
+```
+
+This value will be used only for debugging purposes, and does not affect the functionality otherwise.
+
+In this example, the test-identifier string will appear as part of the console.error message.
+
+### Custom Error Handlers
+
+Both computed and effect signals can receive a custom `errorHandler` property,
+that allows developers to completely override the default functionality that logs and rethrows the error.
+
+#### Effect handlers
+
+For `$effect` handlers, you can pass a function with the following shape:
+
+```typescript
+(error: any) => void
+```
+
+The thrown error will be passed as an argument, and nothing should be returned.
+
+Example:
+
+```javascript
+function customErrorHandlerFn(error) {
+  // custom logic or logging or rethrowing here
+}
+
+$effect(
+  () => {
+    throw new Error("test");
+  },
+  {
+    errorHandler: customErrorHandlerFn
+  }
+);
+```
+
+#### Computed handlers
+
+For `$computed` handlers, you can pass a function with the following shape:
+
+```typescript
+(error: unknown) => T | undefined;
+```
+
+Where you can return nothing, or a value of type `T`, which should be of the same type as the computed value itself.
+This allows you to provide a "fallback" value, that the computed value will receive in case of errors.
+
+Example
+
+```javascript
+function customErrorHandlerFn(error) {
+  // custom logic or logging or rethrowing here
+  return "fallback value";
+}
+
+$computed(
+  () => {
+    throw new Error("test");
+  },
+  {
+    errorHandler: customErrorHandlerFn
+  }
+);
+```
 
 ## Tracking objects and arrays
 
@@ -200,8 +306,8 @@ console.log(computedFromObj.value); // 4
 
 ## Reacting to multiple signals
 
-You can also use multiple signals in a single `computed` and react to changes in any of them.
-This gives you the ability to create complex reactive values that depend on multiple data sources
+You can also use multiple signals in a single `computed` or `effect` and react to changes in any of them.
+This allows you to create complex reactive values that depend on multiple data sources
 without having to track each one independently.
 
 > 👀 You can find the full working code for the following example in the `examples`
@@ -295,22 +401,6 @@ export default class BusinessCard extends LightningElement {
 
 > ❗ Notice that we are using a property instead of a getter in the `$computed` callback function, because
 > we need to reassign the value to `this.contactInfo` to trigger the reactivity, as it is a complex object.
-
-### `$effect`
-
-You can also use the `$effect` function to create a side effect that depends on a signal.
-
-Let's say you want to keep a log of the changes in the `counter` signal.
-
-```javascript
-import { $signal, $effect } from "c/signals";
-
-export const counter = $signal(0);
-
-$effect(() => console.log(counter.value));
-```
-
-> ❗ DO NOT use `$effect` to update the signal value, as it will create an infinite loop.
 
 ## Communicating with Apex data and other asynchronous operations
 
@@ -817,7 +907,8 @@ The following storage helpers are available by default:
   if using a platform event, this will contain the fields of the platform event.
 
   - The `options` (optional) parameter is an object that can contain the following properties (all of them optional):
-    - `replayId` The replay ID to start from, defaults to -1. When -2 is passed, it will replay from the last saved event.
+    - `replayId` The replay ID to start from, defaults to -1. When -2 is passed, it will replay from the last saved
+      event.
     - `onSubscribe` A callback function called when the subscription is successful.
     - `onError` A callback function called when an error response is received from the server for
       handshake, connect, subscribe, and unsubscribe meta channels.

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ In this example, the test-identifier string will appear as part of the console.e
 
 ### Custom Error Handlers
 
-Both computed and effect signals can receive a custom `errorHandler` property,
+Both computed and effect signals can receive a custom `onError` property,
 that allows developers to completely override the default functionality that logs and rethrows the error.
 
 #### Effect handlers
@@ -275,7 +275,7 @@ $effect(
     throw new Error("test");
   },
   {
-    errorHandler: customErrorHandlerFn
+    onError: customErrorHandlerFn
   }
 );
 ```
@@ -304,7 +304,7 @@ $computed(
     throw new Error("test");
   },
   {
-    errorHandler: customErrorHandlerFn
+    onError: customErrorHandlerFn
   }
 );
 ```

--- a/examples/demo-signals/lwc/demoSignals/demoSignals.js
+++ b/examples/demo-signals/lwc/demoSignals/demoSignals.js
@@ -3,3 +3,4 @@ export * from "./contact-info";
 export * from "./apex-fetcher";
 export * from "./shopping-cart";
 export * from "./chat-data-source";
+export * from "./error-handler";

--- a/examples/demo-signals/lwc/demoSignals/error-handler.js
+++ b/examples/demo-signals/lwc/demoSignals/error-handler.js
@@ -8,10 +8,21 @@ $computed(
     throw new Error("An error occurred during a computation");
   },
   {
-    identifier: "computed-with-error"
+    errorHandler: (error) => {
+      console.error("error thrown from computed", error);
+      // Allows for a fallback value to be returned when an error occurs.
+      return 0;
+    }
   }
 );
 
-$effect(() => {
-  throw new Error("An error occurred during an effect");
-});
+$effect(
+  () => {
+    throw new Error("An error occurred during an effect");
+  },
+  {
+    errorHandler: (error) => {
+      console.error("error thrown from effect", error);
+    }
+  }
+);

--- a/examples/demo-signals/lwc/demoSignals/error-handler.js
+++ b/examples/demo-signals/lwc/demoSignals/error-handler.js
@@ -1,0 +1,12 @@
+import { $signal, $computed, $effect } from "c/signals";
+
+const anySignal = $signal(0);
+
+$computed(() => {
+  anySignal.value;
+  throw new Error("An error occurred during a computation");
+});
+
+$effect(() => {
+  throw new Error("An error occurred during an effect");
+});

--- a/examples/demo-signals/lwc/demoSignals/error-handler.js
+++ b/examples/demo-signals/lwc/demoSignals/error-handler.js
@@ -2,10 +2,15 @@ import { $signal, $computed, $effect } from "c/signals";
 
 const anySignal = $signal(0);
 
-$computed(() => {
-  anySignal.value;
-  throw new Error("An error occurred during a computation");
-});
+$computed(
+  () => {
+    anySignal.value;
+    throw new Error("An error occurred during a computation");
+  },
+  {
+    identifier: "computed-with-error"
+  }
+);
 
 $effect(() => {
   throw new Error("An error occurred during an effect");

--- a/examples/demo-signals/lwc/demoSignals/error-handler.js
+++ b/examples/demo-signals/lwc/demoSignals/error-handler.js
@@ -8,10 +8,13 @@ $computed(
     throw new Error("An error occurred during a computation");
   },
   {
-    errorHandler: (error) => {
+    errorHandler: (error /*_previousValue*/) => {
       console.error("error thrown from computed", error);
       // Allows for a fallback value to be returned when an error occurs.
       return 0;
+
+      // The previous value can also be returned to keep the last known value.
+      // return previousValue;
     }
   }
 );

--- a/examples/demo-signals/lwc/demoSignals/error-handler.js
+++ b/examples/demo-signals/lwc/demoSignals/error-handler.js
@@ -1,0 +1,28 @@
+import { $signal, $computed, $effect } from "c/signals";
+
+const anySignal = $signal(0);
+
+$computed(
+  () => {
+    anySignal.value;
+    throw new Error("An error occurred during a computation");
+  },
+  {
+    errorHandler: (error) => {
+      console.error("error thrown from computed", error);
+      // Allows for a fallback value to be returned when an error occurs.
+      return 0;
+    }
+  }
+);
+
+$effect(
+  () => {
+    throw new Error("An error occurred during an effect");
+  },
+  {
+    errorHandler: (error) => {
+      console.error("error thrown from effect", error);
+    }
+  }
+);

--- a/examples/demo-signals/lwc/demoSignals/error-handler.js
+++ b/examples/demo-signals/lwc/demoSignals/error-handler.js
@@ -8,7 +8,7 @@ $computed(
     throw new Error("An error occurred during a computation");
   },
   {
-    errorHandler: (error /*_previousValue*/) => {
+    onError: (error /*_previousValue*/) => {
       console.error("error thrown from computed", error);
       // Allows for a fallback value to be returned when an error occurs.
       return 0;
@@ -24,7 +24,7 @@ $effect(
     throw new Error("An error occurred during an effect");
   },
   {
-    errorHandler: (error) => {
+    onError: (error) => {
       console.error("error thrown from effect", error);
     }
   }

--- a/force-app/lwc/signals/core.js
+++ b/force-app/lwc/signals/core.js
@@ -10,6 +10,10 @@ const UNSET = Symbol("UNSET");
 const COMPUTING = Symbol("COMPUTING");
 const ERRORED = Symbol("ERRORED");
 const READY = Symbol("READY");
+const defaultEffectProps = {
+  _fromComputed: false,
+  identifier: null
+};
 /**
  * Creates a new effect that will be executed immediately and whenever
  * any of the signals it reads from change.
@@ -28,8 +32,10 @@ const READY = Symbol("READY");
  * ```
  *
  * @param fn The function to execute
+ * @param props Options to configure the effect
  */
-function $effect(fn) {
+function $effect(fn, props) {
+  const _props = { ...defaultEffectProps, ...props };
   const effectNode = {
     error: null,
     state: UNSET
@@ -44,17 +50,25 @@ function $effect(fn) {
       fn();
       effectNode.error = null;
       effectNode.state = READY;
+    } catch (error) {
+      effectNode.state = ERRORED;
+      effectNode.error = error;
+      _props.errorHandler
+        ? _props.errorHandler(error)
+        : handleEffectError(error, _props);
     } finally {
       context.pop();
     }
   };
   execute();
 }
-function computedGetter(node) {
-  if (node.state === ERRORED) {
-    throw node.error;
-  }
-  return node.signal.readOnly;
+function handleEffectError(error, props) {
+  const source =
+    (props._fromComputed ? "Computed" : "Effect") +
+    (props.identifier ? ` (${props.identifier})` : "");
+  const errorMessage = `An error occurred in a ${source} function`;
+  console.error(errorMessage, error);
+  throw error;
 }
 /**
  * Creates a new computed value that will be updated whenever the signals
@@ -70,28 +84,33 @@ function computedGetter(node) {
  * ```
  *
  * @param fn The function that returns the computed value.
+ * @param props Options to configure the computed value.
  */
-function $computed(fn) {
-  const computedNode = {
-    signal: $signal(undefined),
-    error: null,
-    state: UNSET
-  };
-  $effect(() => {
-    if (computedNode.state === COMPUTING) {
-      throw new Error("Circular dependency detected");
-    }
-    try {
-      computedNode.state = COMPUTING;
-      computedNode.signal.value = fn();
-      computedNode.error = null;
-      computedNode.state = READY;
-    } catch (error) {
-      computedNode.state = ERRORED;
-      computedNode.error = error;
-    }
+function $computed(fn, props) {
+  const computedSignal = $signal(undefined, {
+    track: true
   });
-  return computedGetter(computedNode);
+  $effect(
+    () => {
+      if (props?.errorHandler) {
+        // If this computed has a custom errorHandler, then error
+        // handling occurs in the computed function itself.
+        try {
+          computedSignal.value = fn();
+        } catch (error) {
+          computedSignal.value = props.errorHandler(error);
+        }
+      } else {
+        // Otherwise, the error handling is done in the $effect
+        computedSignal.value = fn();
+      }
+    },
+    {
+      _fromComputed: true,
+      identifier: props?.identifier ?? null
+    }
+  );
+  return computedSignal.readOnly;
 }
 class UntrackedState {
   constructor(value) {
@@ -102,6 +121,9 @@ class UntrackedState {
   }
   set(value) {
     this._value = value;
+  }
+  forceUpdate() {
+    return false;
   }
 }
 class TrackedState {
@@ -118,6 +140,9 @@ class TrackedState {
   }
   set(value) {
     this._value = this._membrane.getProxy(value);
+  }
+  forceUpdate() {
+    return true;
   }
 }
 /**
@@ -163,7 +188,10 @@ function $signal(value, options) {
     return _storageOption.get();
   }
   function setter(newValue) {
-    if (isEqual(newValue, _storageOption.get())) {
+    if (
+      !trackableState.forceUpdate() &&
+      isEqual(newValue, _storageOption.get())
+    ) {
       return;
     }
     trackableState.set(newValue);
@@ -192,16 +220,17 @@ function $signal(value, options) {
         setter(newValue);
       }
     },
+    brand: Symbol.for("lwc-signals"),
     readOnly: {
       get value() {
         return getter();
       }
     }
   };
-  // We don't want to expose the `get` and `set` methods, so
-  // remove before returning
   delete returnValue.get;
   delete returnValue.set;
+  delete returnValue.registerOnChange;
+  delete returnValue.unsubscribe;
   return returnValue;
 }
 function $resource(fn, source, options) {

--- a/force-app/lwc/signals/core.js
+++ b/force-app/lwc/signals/core.js
@@ -329,4 +329,7 @@ function $resource(fn, source, options) {
     }
   };
 }
-export { $signal, $effect, $computed, $resource };
+function isASignal(anything) {
+  return !!anything && anything.brand === Symbol.for("lwc-signals");
+}
+export { $signal, $effect, $computed, $resource, isASignal };

--- a/force-app/lwc/signals/core.js
+++ b/force-app/lwc/signals/core.js
@@ -11,7 +11,8 @@ const COMPUTING = Symbol("COMPUTING");
 const ERRORED = Symbol("ERRORED");
 const READY = Symbol("READY");
 const defaultEffectProps = {
-  _fromComputed: false
+  _fromComputed: false,
+  identifier: null
 };
 /**
  * Creates a new effect that will be executed immediately and whenever
@@ -60,7 +61,9 @@ function $effect(fn, props) {
   execute();
 }
 function handleEffectError(error, props) {
-  const source = props._fromComputed ? "Computed" : "Effect";
+  const source =
+    (props._fromComputed ? "Computed" : "Effect") +
+    (props.identifier ? ` (${props.identifier})` : "");
   const errorMessage = `An error occurred in a ${source} function`;
   console.error(errorMessage, error);
   throw error;
@@ -79,13 +82,15 @@ function handleEffectError(error, props) {
  * ```
  *
  * @param fn The function that returns the computed value.
+ * @param props Options to configure the computed value.
  */
-function $computed(fn) {
+function $computed(fn, props) {
   const computedSignal = $signal(undefined, {
     track: true
   });
   $effect(() => (computedSignal.value = fn()), {
-    _fromComputed: true
+    _fromComputed: true,
+    identifier: props?.identifier ?? null
   });
   return computedSignal.readOnly;
 }

--- a/force-app/lwc/signals/core.js
+++ b/force-app/lwc/signals/core.js
@@ -44,17 +44,16 @@ function $effect(fn) {
       fn();
       effectNode.error = null;
       effectNode.state = READY;
+    } catch (error) {
+      console.error(error);
+      effectNode.state = ERRORED;
+      effectNode.error = error;
+      throw error;
     } finally {
       context.pop();
     }
   };
   execute();
-}
-function computedGetter(node) {
-  if (node.state === ERRORED) {
-    throw node.error;
-  }
-  return node.signal.readOnly;
 }
 /**
  * Creates a new computed value that will be updated whenever the signals
@@ -72,26 +71,9 @@ function computedGetter(node) {
  * @param fn The function that returns the computed value.
  */
 function $computed(fn) {
-  const computedNode = {
-    signal: $signal(undefined),
-    error: null,
-    state: UNSET
-  };
-  $effect(() => {
-    if (computedNode.state === COMPUTING) {
-      throw new Error("Circular dependency detected");
-    }
-    try {
-      computedNode.state = COMPUTING;
-      computedNode.signal.value = fn();
-      computedNode.error = null;
-      computedNode.state = READY;
-    } catch (error) {
-      computedNode.state = ERRORED;
-      computedNode.error = error;
-    }
-  });
-  return computedGetter(computedNode);
+  const computedSignal = $signal(undefined, { track: true });
+  $effect(() => (computedSignal.value = fn()));
+  return computedSignal.readOnly;
 }
 class UntrackedState {
   constructor(value) {
@@ -102,6 +84,9 @@ class UntrackedState {
   }
   set(value) {
     this._value = value;
+  }
+  forceUpdate() {
+    return false;
   }
 }
 class TrackedState {
@@ -118,6 +103,9 @@ class TrackedState {
   }
   set(value) {
     this._value = this._membrane.getProxy(value);
+  }
+  forceUpdate() {
+    return true;
   }
 }
 /**
@@ -163,7 +151,10 @@ function $signal(value, options) {
     return _storageOption.get();
   }
   function setter(newValue) {
-    if (isEqual(newValue, _storageOption.get())) {
+    if (
+      !trackableState.forceUpdate() &&
+      isEqual(newValue, _storageOption.get())
+    ) {
       return;
     }
     trackableState.set(newValue);
@@ -192,16 +183,17 @@ function $signal(value, options) {
         setter(newValue);
       }
     },
+    brand: Symbol.for("lwc-signals"),
     readOnly: {
       get value() {
         return getter();
       }
     }
   };
-  // We don't want to expose the `get` and `set` methods, so
-  // remove before returning
   delete returnValue.get;
   delete returnValue.set;
+  delete returnValue.registerOnChange;
+  delete returnValue.unsubscribe;
   return returnValue;
 }
 function $resource(fn, source, options) {

--- a/force-app/lwc/signals/core.js
+++ b/force-app/lwc/signals/core.js
@@ -90,10 +90,26 @@ function $computed(fn, props) {
   const computedSignal = $signal(undefined, {
     track: true
   });
-  $effect(() => (computedSignal.value = fn()), {
-    _fromComputed: true,
-    identifier: props?.identifier ?? null
-  });
+  $effect(
+    () => {
+      if (props?.errorHandler) {
+        // If this computed has a custom errorHandler, then error
+        // handling occurs in the computed function itself.
+        try {
+          computedSignal.value = fn();
+        } catch (error) {
+          computedSignal.value = props.errorHandler(error);
+        }
+      } else {
+        // Otherwise, the error handling is done in the $effect
+        computedSignal.value = fn();
+      }
+    },
+    {
+      _fromComputed: true,
+      identifier: props?.identifier ?? null
+    }
+  );
   return computedSignal.readOnly;
 }
 class UntrackedState {

--- a/force-app/lwc/signals/core.js
+++ b/force-app/lwc/signals/core.js
@@ -54,7 +54,7 @@ function $effect(fn, options) {
       effectNode.state = ERRORED;
       effectNode.error = error;
       _optionsWithDefaults.onError
-        ? _optionsWithDefaults.onError(error)
+        ? _optionsWithDefaults.onError(error, _optionsWithDefaults)
         : handleEffectError(error, _optionsWithDefaults);
     } finally {
       context.pop();
@@ -107,7 +107,9 @@ function $computed(fn, options) {
           computedSignal.value = fn();
         } catch (error) {
           const previousValue = computedSignal.peek();
-          computedSignal.value = options.onError(error, previousValue);
+          computedSignal.value = options.onError(error, previousValue, {
+            identifier: _optionsWithDefaults.identifier
+          });
         }
       } else {
         // Otherwise, the error handling is done in the $effect

--- a/force-app/lwc/signals/core.js
+++ b/force-app/lwc/signals/core.js
@@ -53,7 +53,9 @@ function $effect(fn, props) {
     } catch (error) {
       effectNode.state = ERRORED;
       effectNode.error = error;
-      handleEffectError(error, _props);
+      _props.errorHandler
+        ? _props.errorHandler(error)
+        : handleEffectError(error, _props);
     } finally {
       context.pop();
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@salesforce/eslint-plugin-lightning": "^1.0.0",
         "@tailwindcss/forms": "^0.5.7",
         "@types/jest": "^29.5.12",
+        "@types/sinon": "^17.0.3",
         "eslint": "^8.57.0",
         "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-jest": "^27.6.0",
@@ -26,7 +27,7 @@
         "jest-environment-jsdom": "^29.7.0",
         "lint-staged": "^15.1.0",
         "prettier": "^3.1.0",
-        "prettier-plugin-apex": "^2.0.1",
+        "sinon": "^19.0.2",
         "tailwindcss": "^3.4.3",
         "ts-jest": "^29.1.2",
         "ts-node": "^10.9.2",
@@ -705,21 +706,6 @@
       "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
-      "dev": true
-    },
-    "node_modules/@hapi/topo": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
-      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
-      "dev": true,
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1903,27 +1889,6 @@
         "eslint": "^7 || ^8"
       }
     },
-    "node_modules/@sideway/address": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
-      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
-      "dev": true,
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
-    "node_modules/@sideway/formula": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
-      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
-      "dev": true
-    },
-    "node_modules/@sideway/pinpoint": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
-      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
-      "dev": true
-    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -1947,6 +1912,32 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.2.tgz",
+      "integrity": "sha512-v46t/fwnhejRSFTGqbpn9u+LQ9xJDse10gNnPgAcxgdoCDMXj/G2asWAC/8Qs+BAZDicX+MNZouXT1A7c83kVw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.1.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
+      "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
+      "dev": true
     },
     "node_modules/@tailwindcss/forms": {
       "version": "0.5.7",
@@ -2113,6 +2104,21 @@
       "version": "7.5.8",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
       "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+      "dev": true
+    },
+    "node_modules/@types/sinon": {
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.3.tgz",
+      "integrity": "sha512-j3uovdn8ewky9kRBG19bOwaZbexJu/XjtkHyjvUgt4xfPFz18dcORIMqnYh66Fx3Powhcr85NT5+er3+oViapw==",
+      "dev": true,
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
+      "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
       "dev": true
     },
     "node_modules/@types/stack-utils": {
@@ -2729,17 +2735,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/axios": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
-      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
-      "dev": true,
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -4822,26 +4817,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
     },
     "node_modules/for-each": {
       "version": "0.3.3",
@@ -7432,19 +7407,6 @@
         "jiti": "bin/jiti.js"
       }
     },
-    "node_modules/joi": {
-      "version": "17.13.1",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.1.tgz",
-      "integrity": "sha512-vaBlIKCyo4FCUtCm7Eu4QZd/q02bWcxfUO6YSXAZOWF6gzcLBeba8kwotUdYJjDLW8Cz8RywsSOqiNJZW0mNvg==",
-      "dev": true,
-      "dependencies": {
-        "@hapi/hoek": "^9.3.0",
-        "@hapi/topo": "^5.1.0",
-        "@sideway/address": "^4.1.5",
-        "@sideway/formula": "^3.0.1",
-        "@sideway/pinpoint": "^2.0.0"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -7555,6 +7517,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/just-extend": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
+      "dev": true
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -7816,10 +7784,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
     "node_modules/lodash.memoize": {
@@ -8126,6 +8094,28 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/nise": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.1.tgz",
+      "integrity": "sha512-aMSAzLVY7LyeM60gvBS423nBmIPP+Wy7St7hsb+8/fc1HmeoHJfLO8CKse4u3BtOZvQLJghYPI2i/1WZrEj5/g==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.1",
+        "@sinonjs/text-encoding": "^0.7.3",
+        "just-extend": "^6.2.0",
+        "path-to-regexp": "^8.1.0"
+      }
+    },
+    "node_modules/nise/node_modules/@sinonjs/fake-timers": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
+      "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -8449,6 +8439,15 @@
         "node": "14 || >=16.14"
       }
     },
+    "node_modules/path-to-regexp": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -8740,26 +8739,6 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
-    "node_modules/prettier-plugin-apex": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-apex/-/prettier-plugin-apex-2.1.4.tgz",
-      "integrity": "sha512-kGImHH2s+RsPtAXwbh5VmqqSTYhts626Zle2ryeUKJ4VY+vDyOQ53ppWOzFPA1XGdRpthh++WliD0ZVP1kdReA==",
-      "dev": true,
-      "dependencies": {
-        "jest-docblock": "^29.0.0",
-        "wait-on": "^7.2.0"
-      },
-      "bin": {
-        "apex-ast-serializer": "vendor/apex-ast-serializer/bin/apex-ast-serializer",
-        "apex-ast-serializer-http": "vendor/apex-ast-serializer/bin/apex-ast-serializer-http",
-        "install-apex-executables": "dist/bin/install-apex-executables.js",
-        "start-apex-server": "dist/bin/start-apex-server.js",
-        "stop-apex-server": "dist/bin/stop-apex-server.js"
-      },
-      "peerDependencies": {
-        "prettier": "^3.0.0"
-      }
-    },
     "node_modules/pretty-format": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
@@ -8798,12 +8777,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
     },
     "node_modules/psl": {
       "version": "1.9.0",
@@ -9054,15 +9027,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/safe-array-concat": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
@@ -9207,6 +9171,63 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
+    },
+    "node_modules/sinon": {
+      "version": "19.0.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-19.0.2.tgz",
+      "integrity": "sha512-euuToqM+PjO4UgXeLETsfQiuoyPXlqFezr6YZDFwHR3t4qaX0fZUe1MfPMznTL5f8BWrVS89KduLdMUsxFCO6g==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.2",
+        "@sinonjs/samsam": "^8.0.1",
+        "diff": "^7.0.0",
+        "nise": "^6.1.1",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/@sinonjs/fake-timers": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
+      "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/sinon/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sinon/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -9907,12 +9928,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
-    },
     "node_modules/tsutils": {
       "version": "3.21.0",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
@@ -10403,25 +10418,6 @@
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/wait-on": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
-      "integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
-      "dev": true,
-      "dependencies": {
-        "axios": "^1.6.1",
-        "joi": "^17.11.0",
-        "lodash": "^4.17.21",
-        "minimist": "^1.2.8",
-        "rxjs": "^7.8.1"
-      },
-      "bin": {
-        "wait-on": "bin/wait-on"
-      },
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/walker": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@salesforce/eslint-config-lwc": "^3.2.3",
     "@salesforce/eslint-plugin-aura": "^2.0.0",
     "@salesforce/eslint-plugin-lightning": "^1.0.0",
+    "@tailwindcss/forms": "^0.5.7",
     "@types/jest": "^29.5.12",
     "eslint": "^8.57.0",
     "eslint-plugin-import": "^2.25.4",
@@ -33,12 +34,11 @@
     "jest-environment-jsdom": "^29.7.0",
     "lint-staged": "^15.1.0",
     "prettier": "^3.1.0",
+    "tailwindcss": "^3.4.3",
     "ts-jest": "^29.1.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.5",
-    "typescript-eslint": "^7.9.0",
-    "tailwindcss": "^3.4.3",
-    "@tailwindcss/forms": "^0.5.7"
+    "typescript-eslint": "^7.9.0"
   },
   "lint-staged": {
     "**/*.{cmp,component,css,html,js,json,md,page,trigger,xml,yaml,yml}": [

--- a/src/lwc/signals/__tests__/computed.test.ts
+++ b/src/lwc/signals/__tests__/computed.test.ts
@@ -160,4 +160,35 @@ describe("computed values", () => {
 
     expect(computed.value).toBe(1);
   });
+
+  test("allows for custom error handlers to have access to the identifier", () => {
+    const signal = $signal(0);
+    const identifier = "test-identifier";
+    function customErrorHandlerFn(_error: unknown, _previousValue: number | undefined, options: { identifier: string | symbol }) {
+      return options.identifier;
+    }
+
+    const computed = $computed(() => {
+      if (signal.value === 2) {
+        throw new Error("test");
+      }
+
+      return signal.value;
+    }, {
+      // @ts-expect-error This is just for testing purposes, we are overriding the return type of the function
+      // which usually we should not do.
+      onError: customErrorHandlerFn,
+      identifier
+    });
+
+    expect(computed.value).toBe(0);
+
+    signal.value = 1;
+
+    expect(computed.value).toBe(1)
+
+    signal.value = 2;
+
+    expect(computed.value).toBe(identifier);
+  });
 });

--- a/src/lwc/signals/__tests__/computed.test.ts
+++ b/src/lwc/signals/__tests__/computed.test.ts
@@ -128,4 +128,31 @@ describe("computed values", () => {
 
     expect(computed.value).toBe("fallback");
   });
+
+  test("allows for custom error handlers to return the previous value", () => {
+    const signal = $signal(0);
+    function customErrorHandlerFn(_error: unknown, previousValue: number | undefined) {
+      return previousValue;
+    }
+
+    const computed = $computed(() => {
+      if (signal.value === 2) {
+        throw new Error("test");
+      }
+
+      return signal.value;
+    }, {
+      errorHandler: customErrorHandlerFn
+    });
+
+    expect(computed.value).toBe(0);
+
+    signal.value = 1;
+
+    expect(computed.value).toBe(1)
+
+    signal.value = 2;
+
+    expect(computed.value).toBe(1);
+  });
 });

--- a/src/lwc/signals/__tests__/computed.test.ts
+++ b/src/lwc/signals/__tests__/computed.test.ts
@@ -114,7 +114,7 @@ describe("computed values", () => {
     $computed(() => {
       throw new Error("test");
     }, {
-      errorHandler: customErrorHandlerFn
+      onError: customErrorHandlerFn
     });
 
     expect(customErrorHandlerFn).toHaveBeenCalled();
@@ -128,7 +128,7 @@ describe("computed values", () => {
     const computed = $computed(() => {
       throw new Error("test");
     }, {
-      errorHandler: customErrorHandlerFn
+      onError: customErrorHandlerFn
     });
 
     expect(computed.value).toBe("fallback");
@@ -147,7 +147,7 @@ describe("computed values", () => {
 
       return signal.value;
     }, {
-      errorHandler: customErrorHandlerFn
+      onError: customErrorHandlerFn
     });
 
     expect(computed.value).toBe(0);

--- a/src/lwc/signals/__tests__/computed.test.ts
+++ b/src/lwc/signals/__tests__/computed.test.ts
@@ -102,4 +102,30 @@ describe("computed values", () => {
 
     spy.mockRestore();
   });
+
+  test("allow for errors to be handled through a custom function", () => {
+    const customErrorHandlerFn = jest.fn() as (error: unknown) => void;
+
+    $computed(() => {
+      throw new Error("test");
+    }, {
+      errorHandler: customErrorHandlerFn
+    });
+
+    expect(customErrorHandlerFn).toHaveBeenCalled();
+  });
+
+  test("allow for errors to be handled through a custom function and return a fallback value", () => {
+    function customErrorHandlerFn() {
+      return "fallback";
+    }
+
+    const computed = $computed(() => {
+      throw new Error("test");
+    }, {
+      errorHandler: customErrorHandlerFn
+    });
+
+    expect(computed.value).toBe("fallback");
+  });
 });

--- a/src/lwc/signals/__tests__/computed.test.ts
+++ b/src/lwc/signals/__tests__/computed.test.ts
@@ -1,4 +1,4 @@
-import { $computed, $signal } from "../core";
+import { $computed, $effect, $signal } from "../core";
 
 describe("computed values", () => {
   test("can be created from a source signal", () => {
@@ -45,5 +45,16 @@ describe("computed values", () => {
 
     expect(computed.value).toBe(2);
     expect(anotherComputed.value).toBe(4);
+  });
+
+  test("computed objects that return the same value as a tracked signal recomputes", () => {
+    const signal = $signal({ a: 0, b: 0 }, { track: true });
+    const computed = $computed(() => signal.value);
+    const spy = jest.fn(() => computed.value);
+    $effect(spy);
+    spy.mockReset();
+
+    signal.value.a = 1;
+    expect(spy).toHaveBeenCalled();
   });
 });

--- a/src/lwc/signals/__tests__/computed.test.ts
+++ b/src/lwc/signals/__tests__/computed.test.ts
@@ -57,4 +57,32 @@ describe("computed values", () => {
     signal.value.a = 1;
     expect(spy).toHaveBeenCalled();
   });
+
+  test("throw an error when a circular dependency is detected", () => {
+    console.error = jest.fn();
+    expect(() => {
+      const signal = $signal(0);
+      $computed(() => {
+        signal.value = signal.value++;
+        return signal.value;
+      });
+    }).toThrow();
+  });
+
+  test("console errors when a computed throws an error", () => {
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const signal = $signal(0);
+      $computed(() => {
+        signal.value;
+        throw new Error("error");
+      });
+      signal.value = 1;
+    } catch (e) {
+      expect(spy).toHaveBeenCalled();
+    }
+
+    spy.mockRestore();
+  });
 });

--- a/src/lwc/signals/__tests__/computed.test.ts
+++ b/src/lwc/signals/__tests__/computed.test.ts
@@ -85,4 +85,21 @@ describe("computed values", () => {
 
     spy.mockRestore();
   });
+
+  test("console errors with an identifier when one was provided", () => {
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const signal = $signal(0);
+      $computed(() => {
+        signal.value;
+        throw new Error("error");
+      }, { identifier: "test-identifier" });
+      signal.value = 1;
+    } catch (e) {
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining("test-identifier"), expect.any(Error));
+    }
+
+    spy.mockRestore();
+  });
 });

--- a/src/lwc/signals/__tests__/computed.test.ts
+++ b/src/lwc/signals/__tests__/computed.test.ts
@@ -86,6 +86,11 @@ describe("computed values", () => {
     spy.mockRestore();
   });
 
+  test("have a default identifier", () => {
+    const computed = $computed(() => {});
+    expect(computed.identifier).toBeDefined();
+  });
+
   test("console errors with an identifier when one was provided", () => {
     const spy = jest.spyOn(console, "error").mockImplementation(() => {});
 

--- a/src/lwc/signals/__tests__/effect.test.ts
+++ b/src/lwc/signals/__tests__/effect.test.ts
@@ -40,6 +40,11 @@ describe("effects", () => {
     }).toThrow();
   });
 
+  test("return an object with an identifier", () => {
+    const effect = $effect(() => {});
+    expect(effect.identifier).toBeDefined();
+  });
+
   test("console errors when an effect throws an error", () => {
     const spy = jest.spyOn(console, "error").mockImplementation(() => {});
     try {
@@ -49,6 +54,59 @@ describe("effects", () => {
     } catch (error) {
       expect(spy).toHaveBeenCalled();
     }
+    spy.mockRestore();
+  });
+
+  test("console errors with the default identifier", () => {
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    const signal = $signal(0);
+    const effect = $effect(() => {
+      if (signal.value === 1) {
+        throw new Error("test");
+      }
+    });
+
+    try {
+      signal.value = 1;
+    } catch (e) {
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining(effect.identifier.toString()), expect.any(Error));
+    }
+
+    spy.mockRestore();
+  });
+
+  test("allow for the identifier to be overridden", () => {
+    const signal = $signal(0);
+    const effect = $effect(() => {
+      if (signal.value === 1) {
+        throw new Error("test");
+      }
+    }, {
+      identifier: "test-identifier"
+    });
+
+    expect(effect.identifier).toBe("test-identifier");
+  });
+
+  test("console errors with a custom identifier if provided", () => {
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    const signal = $signal(0);
+    $effect(() => {
+      if (signal.value === 1) {
+        throw new Error("test");
+      }
+    }, {
+      identifier: "test-identifier"
+    });
+
+    try {
+      signal.value = 1;
+    } catch (e) {
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining("test-identifier"), expect.any(Error));
+    }
+
     spy.mockRestore();
   });
 

--- a/src/lwc/signals/__tests__/effect.test.ts
+++ b/src/lwc/signals/__tests__/effect.test.ts
@@ -1,18 +1,33 @@
 import { $signal, $effect } from "../core";
 
 describe("effects", () => {
+  test("react to the callback immediately", () => {
+    const signal = $signal(0);
+    const spy = jest.fn(() => signal.value);
+    $effect(spy);
+    expect(spy).toHaveBeenCalled();
+  });
+
   test("react to updates in a signal", () => {
     const signal = $signal(0);
-    let effectTracker = 0;
-
-    $effect(() => {
-      effectTracker = signal.value;
-    });
-
-    expect(effectTracker).toBe(0);
+    const spy = jest.fn(() => signal.value);
+    $effect(spy);
+    spy.mockReset();
 
     signal.value = 1;
-    expect(effectTracker).toBe(1);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  test("react to updates in multiple signals", () => {
+    const a = $signal(0);
+    const b = $signal(0);
+    const spy = jest.fn(() => a.value + b.value);
+    $effect(spy);
+    spy.mockReset();
+
+    a.value = 1;
+    b.value = 1;
+    expect(spy).toHaveBeenCalledTimes(2);
   });
 
   test("throw an error when a circular dependency is detected", () => {

--- a/src/lwc/signals/__tests__/effect.test.ts
+++ b/src/lwc/signals/__tests__/effect.test.ts
@@ -31,11 +31,24 @@ describe("effects", () => {
   });
 
   test("throw an error when a circular dependency is detected", () => {
+    console.error = jest.fn();
     expect(() => {
       const signal = $signal(0);
       $effect(() => {
         signal.value = signal.value++;
       });
     }).toThrow();
+  });
+
+  test("console errors when an effect throws an error", () => {
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      $effect(() => {
+        throw new Error("test");
+      });
+    } catch (error) {
+      expect(spy).toHaveBeenCalled();
+    }
+    spy.mockRestore();
   });
 });

--- a/src/lwc/signals/__tests__/effect.test.ts
+++ b/src/lwc/signals/__tests__/effect.test.ts
@@ -121,6 +121,19 @@ describe("effects", () => {
     expect(customErrorHandlerFn).toHaveBeenCalled();
   });
 
+  test("give access to the effect identifier in the onError handler", () => {
+    function customErrorHandler(_error: unknown, options: { identifier: string | symbol }) {
+      expect(options.identifier).toBe("test-identifier");
+    }
+
+    $effect(() => {
+      throw new Error("test");
+    }, {
+      identifier: "test-identifier",
+      onError: customErrorHandler
+    });
+  });
+
   test("can change and read a signal value without causing a cycle by peeking at it", () => {
     const counter = $signal(0);
     $effect(() => {

--- a/src/lwc/signals/__tests__/effect.test.ts
+++ b/src/lwc/signals/__tests__/effect.test.ts
@@ -115,7 +115,7 @@ describe("effects", () => {
     $effect(() => {
       throw new Error("test");
     }, {
-      errorHandler: customErrorHandlerFn
+      onError: customErrorHandlerFn
     });
 
     expect(customErrorHandlerFn).toHaveBeenCalled();

--- a/src/lwc/signals/__tests__/effect.test.ts
+++ b/src/lwc/signals/__tests__/effect.test.ts
@@ -51,4 +51,15 @@ describe("effects", () => {
     }
     spy.mockRestore();
   });
+
+  test("allow for errors to be handled through a custom function", () => {
+    const customErrorHandlerFn = jest.fn();
+    $effect(() => {
+      throw new Error("test");
+    }, {
+      errorHandler: customErrorHandlerFn
+    });
+
+    expect(customErrorHandlerFn).toHaveBeenCalled();
+  });
 });

--- a/src/lwc/signals/__tests__/effect.test.ts
+++ b/src/lwc/signals/__tests__/effect.test.ts
@@ -31,11 +31,35 @@ describe("effects", () => {
   });
 
   test("throw an error when a circular dependency is detected", () => {
+    console.error = jest.fn();
     expect(() => {
       const signal = $signal(0);
       $effect(() => {
         signal.value = signal.value++;
       });
     }).toThrow();
+  });
+
+  test("console errors when an effect throws an error", () => {
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      $effect(() => {
+        throw new Error("test");
+      });
+    } catch (error) {
+      expect(spy).toHaveBeenCalled();
+    }
+    spy.mockRestore();
+  });
+
+  test("allow for errors to be handled through a custom function", () => {
+    const customErrorHandlerFn = jest.fn();
+    $effect(() => {
+      throw new Error("test");
+    }, {
+      errorHandler: customErrorHandlerFn
+    });
+
+    expect(customErrorHandlerFn).toHaveBeenCalled();
   });
 });

--- a/src/lwc/signals/__tests__/effect.test.ts
+++ b/src/lwc/signals/__tests__/effect.test.ts
@@ -40,6 +40,11 @@ describe("effects", () => {
     }).toThrow();
   });
 
+  test("return an object with an identifier", () => {
+    const effect = $effect(() => {});
+    expect(effect.identifier).toBeDefined();
+  });
+
   test("console errors when an effect throws an error", () => {
     const spy = jest.spyOn(console, "error").mockImplementation(() => {});
     try {
@@ -52,15 +57,81 @@ describe("effects", () => {
     spy.mockRestore();
   });
 
+  test("console errors with the default identifier", () => {
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    const signal = $signal(0);
+    const effect = $effect(() => {
+      if (signal.value === 1) {
+        throw new Error("test");
+      }
+    });
+
+    try {
+      signal.value = 1;
+    } catch (e) {
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining(effect.identifier.toString()), expect.any(Error));
+    }
+
+    spy.mockRestore();
+  });
+
+  test("allow for the identifier to be overridden", () => {
+    const signal = $signal(0);
+    const effect = $effect(() => {
+      if (signal.value === 1) {
+        throw new Error("test");
+      }
+    }, {
+      identifier: "test-identifier"
+    });
+
+    expect(effect.identifier).toBe("test-identifier");
+  });
+
+  test("console errors with a custom identifier if provided", () => {
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    const signal = $signal(0);
+    $effect(() => {
+      if (signal.value === 1) {
+        throw new Error("test");
+      }
+    }, {
+      identifier: "test-identifier"
+    });
+
+    try {
+      signal.value = 1;
+    } catch (e) {
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining("test-identifier"), expect.any(Error));
+    }
+
+    spy.mockRestore();
+  });
+
   test("allow for errors to be handled through a custom function", () => {
     const customErrorHandlerFn = jest.fn();
     $effect(() => {
       throw new Error("test");
     }, {
-      errorHandler: customErrorHandlerFn
+      onError: customErrorHandlerFn
     });
 
     expect(customErrorHandlerFn).toHaveBeenCalled();
+  });
+
+  test("give access to the effect identifier in the onError handler", () => {
+    function customErrorHandler(_error: unknown, options: { identifier: string | symbol }) {
+      expect(options.identifier).toBe("test-identifier");
+    }
+
+    $effect(() => {
+      throw new Error("test");
+    }, {
+      identifier: "test-identifier",
+      onError: customErrorHandler
+    });
   });
 
   test("can change and read a signal value without causing a cycle by peeking at it", () => {

--- a/src/lwc/signals/__tests__/effect.test.ts
+++ b/src/lwc/signals/__tests__/effect.test.ts
@@ -62,4 +62,14 @@ describe("effects", () => {
 
     expect(customErrorHandlerFn).toHaveBeenCalled();
   });
+
+  test("can change and read a signal value without causing a cycle by peeking at it", () => {
+    const counter = $signal(0);
+    $effect(() => {
+      // Without peeking, this kind of operation would cause a circular dependency.
+      counter.value = counter.peek() + 1;
+    });
+
+    expect(counter.value).toBe(1);
+  });
 });

--- a/src/lwc/signals/__tests__/signal-identity.test.ts
+++ b/src/lwc/signals/__tests__/signal-identity.test.ts
@@ -1,38 +1,38 @@
-import { $signal, isASignal } from "../core";
+import { $signal, isSignal } from "../core";
 
 describe("isASignal", () => {
   test("checks that a value is a signal", () => {
     const signal = $signal(0);
-    expect(isASignal(signal)).toBe(true);
+    expect(isSignal(signal)).toBe(true);
   });
 
   test("checks that a computed is a signal", () => {
     const signal = $signal(0);
     const computed = $signal(() => signal.value);
-    expect(isASignal(computed)).toBe(true);
+    expect(isSignal(computed)).toBe(true);
   });
 
   test("checks that a value is not a signal", () => {
-    expect(isASignal(0)).toBe(false);
+    expect(isSignal(0)).toBe(false);
   });
 
   test("checks that a function is not a signal", () => {
-    expect(isASignal(() => {})).toBe(false);
+    expect(isSignal(() => {})).toBe(false);
   });
 
   test("checks that an object is not a signal", () => {
-    expect(isASignal({})).toBe(false);
+    expect(isSignal({})).toBe(false);
   });
 
   test("checks that an array is not a signal", () => {
-    expect(isASignal([])).toBe(false);
+    expect(isSignal([])).toBe(false);
   });
 
   test("checks that undefined is not a signal", () => {
-    expect(isASignal(undefined)).toBe(false);
+    expect(isSignal(undefined)).toBe(false);
   });
 
   test("checks that null is not a signal", () => {
-    expect(isASignal(null)).toBe(false);
+    expect(isSignal(null)).toBe(false);
   });
 });

--- a/src/lwc/signals/__tests__/signal-identity.test.ts
+++ b/src/lwc/signals/__tests__/signal-identity.test.ts
@@ -1,0 +1,38 @@
+import { $signal, isASignal } from "../core";
+
+describe("isASignal", () => {
+  test("checks that a value is a signal", () => {
+    const signal = $signal(0);
+    expect(isASignal(signal)).toBe(true);
+  });
+
+  test("checks that a computed is a signal", () => {
+    const signal = $signal(0);
+    const computed = $signal(() => signal.value);
+    expect(isASignal(computed)).toBe(true);
+  });
+
+  test("checks that a value is not a signal", () => {
+    expect(isASignal(0)).toBe(false);
+  });
+
+  test("checks that a function is not a signal", () => {
+    expect(isASignal(() => {})).toBe(false);
+  });
+
+  test("checks that an object is not a signal", () => {
+    expect(isASignal({})).toBe(false);
+  });
+
+  test("checks that an array is not a signal", () => {
+    expect(isASignal([])).toBe(false);
+  });
+
+  test("checks that undefined is not a signal", () => {
+    expect(isASignal(undefined)).toBe(false);
+  });
+
+  test("checks that null is not a signal", () => {
+    expect(isASignal(null)).toBe(false);
+  });
+});

--- a/src/lwc/signals/__tests__/signals.test.ts
+++ b/src/lwc/signals/__tests__/signals.test.ts
@@ -25,6 +25,11 @@ describe("signals", () => {
 
     expect(debouncedSignal.value).toBe(1);
   });
+
+  test("should be identified with a symbol", () => {
+    const signal = $signal(0);
+    expect(signal.brand).toBe(Symbol.for("lwc-signals"));
+  });
 });
 
 

--- a/src/lwc/signals/__tests__/signals.test.ts
+++ b/src/lwc/signals/__tests__/signals.test.ts
@@ -30,6 +30,14 @@ describe("signals", () => {
     const signal = $signal(0);
     expect(signal.brand).toBe(Symbol.for("lwc-signals"));
   });
+
+  test("allow for peeking the value without triggering a reactivity", () => {
+    const signal = $signal(0);
+    const spy = jest.fn(() => signal.value);
+    const value = signal.peek();
+    expect(spy).not.toHaveBeenCalled();
+    expect(value).toBe(0);
+  });
 });
 
 

--- a/src/lwc/signals/core.ts
+++ b/src/lwc/signals/core.ts
@@ -32,10 +32,12 @@ interface EffectNode {
 
 type EffectProps = {
   _fromComputed: boolean;
+  identifier: string | null;
 };
 
 const defaultEffectProps: EffectProps = {
-  _fromComputed: false
+  _fromComputed: false,
+  identifier: null
 };
 
 /**
@@ -89,13 +91,16 @@ function $effect(fn: VoidFunction, props?: Partial<EffectProps>): void {
 }
 
 function handleEffectError(error: unknown, props: EffectProps) {
-  const source = props._fromComputed ? "Computed" : "Effect";
+  const source = (props._fromComputed ? "Computed" : "Effect") + (props.identifier ? ` (${props.identifier})` : "");
   const errorMessage = `An error occurred in a ${source} function`;
   console.error(errorMessage, error);
   throw error;
 }
 
 type ComputedFunction<T> = () => T;
+type ComputedProps = {
+  identifier: string | null;
+}
 
 /**
  * Creates a new computed value that will be updated whenever the signals
@@ -111,13 +116,15 @@ type ComputedFunction<T> = () => T;
  * ```
  *
  * @param fn The function that returns the computed value.
+ * @param props Options to configure the computed value.
  */
-function $computed<T>(fn: ComputedFunction<T>): ReadOnlySignal<T> {
+function $computed<T>(fn: ComputedFunction<T>, props?: ComputedProps): ReadOnlySignal<T> {
   const computedSignal: Signal<T | undefined> = $signal(undefined, {
     track: true
   });
   $effect(() => (computedSignal.value = fn()), {
-    _fromComputed: true
+    _fromComputed: true,
+    identifier: props?.identifier ?? null
   });
   return computedSignal.readOnly as ReadOnlySignal<T>;
 }

--- a/src/lwc/signals/core.ts
+++ b/src/lwc/signals/core.ts
@@ -12,6 +12,7 @@ export type Signal<T> = {
   set value(newValue: T);
   readOnly: ReadOnlySignal<T>;
   brand: symbol;
+  peek(): T;
 };
 
 const context: VoidFunction[] = [];
@@ -105,7 +106,7 @@ function handleEffectError(error: unknown, props: EffectProps) {
 type ComputedFunction<T> = () => T;
 type ComputedProps<T> = {
   identifier: string | null;
-  errorHandler?: (error: unknown) => T | undefined;
+  errorHandler?: (error: unknown, previousValue: T | undefined) => T | undefined;
 };
 
 /**
@@ -139,7 +140,8 @@ function $computed<T>(
         try {
           computedSignal.value = fn();
         } catch (error) {
-          computedSignal.value = props.errorHandler(error);
+          const previousValue = computedSignal.peek();
+          computedSignal.value = props.errorHandler(error, previousValue);
         }
       } else {
         // Otherwise, the error handling is done in the $effect
@@ -306,6 +308,9 @@ function $signal<T>(
         get value() {
           return getter();
         }
+      },
+      peek() {
+        return _storageOption.get();
       }
     };
 

--- a/src/lwc/signals/core.ts
+++ b/src/lwc/signals/core.ts
@@ -11,6 +11,7 @@ export type Signal<T> = {
   get value(): T;
   set value(newValue: T);
   readOnly: ReadOnlySignal<T>;
+  brand: symbol;
 };
 
 const context: VoidFunction[] = [];
@@ -264,6 +265,7 @@ function $signal<T>(
           setter(newValue);
         }
       },
+      brand: Symbol.for("lwc-signals"),
       readOnly: {
         get value() {
           return getter();
@@ -271,10 +273,10 @@ function $signal<T>(
       }
     };
 
-  // We don't want to expose the `get` and `set` methods, so
-  // remove before returning
   delete returnValue.get;
   delete returnValue.set;
+  delete returnValue.registerOnChange;
+  delete returnValue.unsubscribe;
 
   return returnValue;
 }

--- a/src/lwc/signals/core.ts
+++ b/src/lwc/signals/core.ts
@@ -534,4 +534,8 @@ function $resource<ReturnType, Params>(
   };
 }
 
-export { $signal, $effect, $computed, $resource };
+function isASignal(anything: unknown): anything is Signal<unknown> {
+  return !!anything && (anything as Signal<unknown>).brand === Symbol.for("lwc-signals");
+}
+
+export { $signal, $effect, $computed, $resource, isASignal };

--- a/src/lwc/signals/core.ts
+++ b/src/lwc/signals/core.ts
@@ -246,6 +246,8 @@ class TrackedState<T> implements TrackableState<T> {
   }
 }
 
+const SIGNAL_OBJECT_BRAND = Symbol.for("lwc-signals");
+
 /**
  * Creates a new signal with the provided value. A signal is a reactive
  * primitive that can be used to store and update values. Signals can be
@@ -331,7 +333,7 @@ function $signal<T>(
           setter(newValue);
         }
       },
-      brand: Symbol.for("lwc-signals"),
+      brand: SIGNAL_OBJECT_BRAND,
       readOnly: {
         get value() {
           return getter();
@@ -534,8 +536,8 @@ function $resource<ReturnType, Params>(
   };
 }
 
-function isASignal(anything: unknown): anything is Signal<unknown> {
-  return !!anything && (anything as Signal<unknown>).brand === Symbol.for("lwc-signals");
+function isSignal(anything: unknown): anything is Signal<unknown> {
+  return !!anything && (anything as Signal<unknown>).brand === SIGNAL_OBJECT_BRAND;
 }
 
-export { $signal, $effect, $computed, $resource, isASignal };
+export { $signal, $effect, $computed, $resource, isSignal };

--- a/src/lwc/signals/core.ts
+++ b/src/lwc/signals/core.ts
@@ -38,7 +38,7 @@ interface EffectNode {
 type EffectOptions = {
   _fromComputed: boolean;
   identifier: string | symbol;
-  errorHandler?: (error: unknown) => void;
+  onError?: (error: unknown) => void;
 };
 
 const defaultEffectOptions: EffectOptions = {
@@ -87,8 +87,8 @@ function $effect(fn: VoidFunction, options?: Partial<EffectOptions>): Effect {
     } catch (error) {
       effectNode.state = ERRORED;
       effectNode.error = error;
-      _optionsWithDefaults.errorHandler
-        ? _optionsWithDefaults.errorHandler(error)
+      _optionsWithDefaults.onError
+        ? _optionsWithDefaults.onError(error)
         : handleEffectError(error, _optionsWithDefaults);
     } finally {
       context.pop();
@@ -116,7 +116,7 @@ function handleEffectError(error: unknown, options: EffectOptions) {
 type ComputedFunction<T> = () => T;
 type ComputedOptions<T> = {
   identifier: string | symbol;
-  errorHandler?: (
+  onError?: (
     error: unknown,
     previousValue: T | undefined
   ) => T | undefined;
@@ -156,14 +156,14 @@ function $computed<T>(
   });
   $effect(
     () => {
-      if (options?.errorHandler) {
-        // If this computed has a custom errorHandler, then error
+      if (options?.onError) {
+        // If this computed has a custom error handler, then the
         // handling occurs in the computed function itself.
         try {
           computedSignal.value = fn();
         } catch (error) {
           const previousValue = computedSignal.peek();
-          computedSignal.value = options.errorHandler(error, previousValue);
+          computedSignal.value = options.onError(error, previousValue);
         }
       } else {
         // Otherwise, the error handling is done in the $effect


### PR DESCRIPTION
Next minor release.

Contains:

# Improved error handling

Improves the error handling experience by providing a couple of features to debug and/or modify the way errors are handled when issues occur in a `$computed` or an `$effect`

## Errors are now surfaced as a `console.error` by default

Before, when an error occurred in a computed or an effect, the exception was rethrown. The issue is that Salesforce handles these exceptions differently based on the environment. For example, LWC debugging might be on/off, which changes how errors are surfaced, and errors are handled differently in LWR templates, where the user is redirected to the `error` page.

To improve this experience, when an error occurs in either a computed or effect function, a console.error will be called so that the error is easier to detect (the exception will still be retrhwon after logging).

## Computed and effects can now have an "identifier" for logging purposes.

Following on the previous improvement, if you want to pinpoint exactly which effect or which computed values is the one throwing the exception, a new `identifier` property was introduced. This is only for debugging purposes, and does not affect the functionality otherwise. 

Example

```
      $computed(() => {
        signal.value;
        throw new Error("error");
      }, { identifier: "test-identifier" });
```

In this example, the `test-identifier` string will appear as part of the `console.error` message.

## Computed and effects can now have custom error handlers

Both computed and effect signals can receive a custom `errorHandler` property, that allows developers to **completely override** the default functionality that logs and rethrows the error.

### Effect handlers

For `$effect` handlers, you can pass a function with the following shape:

```
(error) => void
```

The thrown error will be passed as an argument, and nothing should be returned.

Example:

```
    function customErrorHandlerFn(error) {
      // custom logic or logging or rethrowing here
    }
    $effect(() => {
      throw new Error("test");
    }, {
      errorHandler: customErrorHandlerFn
    });
```

### Computed handlers

For `$computed` handlers, you can pass a function with the following shape:

```
(error: unknown) => T | undefined
```

Where you can return nothing, or a value of type `T`, which should be of the same type as the computed value itself. This allows you to provide a "fallback" value, that the computed value will receive in case of errors.

Example

```
    function customErrorHandlerFn(error) {
      // custom logic or logging or rethrowing here
     return "fallback value";
    }
    $computed(() => {
      throw new Error("test");
    }, {
      errorHandler: customErrorHandlerFn
    });
```

# Suite of additional unit tests
# Other minor fixes and improvements