### PR TITLE
fix: update Binder class and bind function for improved type safety

### DIFF
--- a/force-app/lwc/signals/core.js
+++ b/force-app/lwc/signals/core.js
@@ -314,11 +314,16 @@ function $resource(fn, source, options) {
         error: null
       };
     } catch (error) {
-      _signal.value = onError(error, _value, { identifier, initialValue }) ?? {
-        data: null,
-        loading: false,
-        error
-      };
+      const errorValue = onError(error, _value, { identifier, initialValue });
+      if (errorValue) {
+        _signal.value = errorValue;
+      } else {
+        _signal.value = {
+          data: null,
+          loading: false,
+          error
+        };
+      }
     } finally {
       _isInitialLoad = false;
     }

--- a/src/lwc/signals/core.ts
+++ b/src/lwc/signals/core.ts
@@ -599,10 +599,10 @@ function isSignal(anything: unknown): anything is Signal<unknown> {
   );
 }
 
-class Binder {
+class Binder<Element extends HTMLElement> {
   constructor(
-    private component: Record<string, object>,
-    private propertyName: string
+    private component: Element,
+    private propertyName: keyof Element,
   ) {}
 
   to<T>(signal: Signal<T>) {
@@ -615,8 +615,8 @@ class Binder {
   }
 }
 
-function bind(component: Record<string, object>, propertyName: string) {
-  return new Binder(component, propertyName);
+function bind<T extends HTMLElement>(component: T, propertyName: keyof T) {
+  return new Binder<T>(component, propertyName);
 }
 
 export {
@@ -628,3 +628,4 @@ export {
   bind as $bind,
   isSignal
 };
+


### PR DESCRIPTION
When using this library with Typescript, the `$bind` function now provides type safety. It will let you know if you are using a key that is not valid.